### PR TITLE
ci(php-client): drop assistant co-author trailers from the mirror

### DIFF
--- a/.github/scripts/split-php-client.py
+++ b/.github/scripts/split-php-client.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Split clients/client-laravel into a standalone history for the php-client mirror.
+
+The split keeps every source commit, but drops assistant co-author trailers from
+the messages so the public mirror credits only the humans who wrote the package.
+The rewrite is deterministic: the same source commit always produces the same
+mirror commit, so the mirror stays fast-forwardable across runs.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+PREFIX = "clients/client-laravel"
+ASSISTANT_TRAILER = re.compile(
+    r"^\s*Co-Authored-By:\s*Claude\b", re.IGNORECASE
+)
+
+
+def git(*args, **kwargs):
+    return subprocess.run(
+        ("git",) + args, check=True, capture_output=True, **kwargs
+    ).stdout
+
+
+def strip_assistant_trailers(message):
+    kept = [
+        line
+        for line in message.decode("utf-8", "replace").split("\n")
+        if not ASSISTANT_TRAILER.match(line)
+    ]
+    collapsed = re.sub(r"\n{3,}", "\n\n", "\n".join(kept))
+    return (collapsed.rstrip("\n") + "\n").encode()
+
+
+def split(source):
+    output = subprocess.run(
+        ("git", "subtree", "split", "--prefix=" + PREFIX, source),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+    ).stdout
+    return output.decode().split()[-1]
+
+
+def rewrite(split_commit):
+    rewritten = {}
+    revisions = git(
+        "rev-list", "--reverse", "--topo-order", split_commit
+    ).decode().split()
+    for revision in revisions:
+        fields = git(
+            "show", "--no-patch", "--format=%T%n%P%n%an%n%ae%n%aI%n%cn%n%ce%n%cI",
+            revision,
+        ).decode().split("\n")
+        tree, parents = fields[0], fields[1].split()
+        environment = {
+            "GIT_AUTHOR_NAME": fields[2],
+            "GIT_AUTHOR_EMAIL": fields[3],
+            "GIT_AUTHOR_DATE": fields[4],
+            "GIT_COMMITTER_NAME": fields[5],
+            "GIT_COMMITTER_EMAIL": fields[6],
+            "GIT_COMMITTER_DATE": fields[7],
+        }
+        arguments = ["commit-tree", tree]
+        for parent in parents:
+            arguments += ["-p", rewritten[parent]]
+        message = strip_assistant_trailers(git("show", "--no-patch", "--format=%B", revision))
+        rewritten[revision] = subprocess.run(
+            ("git",) + tuple(arguments),
+            check=True,
+            input=message,
+            capture_output=True,
+            env={**os.environ, **environment},
+        ).stdout.decode().strip()
+    return rewritten[revisions[-1]]
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: split-php-client.py <source-commit>", file=sys.stderr)
+        return 2
+    source = sys.argv[1]
+    mirror_commit = rewrite(split(source))
+    expected_tree = git("rev-parse", source + ":" + PREFIX).decode().strip()
+    actual_tree = git("rev-parse", mirror_commit + "^{tree}").decode().strip()
+    if expected_tree != actual_tree:
+        print("split tree does not match the source package", file=sys.stderr)
+        return 1
+    print(mirror_commit)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release-php-client.yml
+++ b/.github/workflows/release-php-client.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Prepare the source subtree
         run: |
           set -Eeuo pipefail
-          split_commit=$(git subtree split --prefix=clients/client-laravel HEAD)
+          split_commit=$(python3 .github/scripts/split-php-client.py HEAD)
           expected_tree=$(git rev-parse HEAD:clients/client-laravel)
           test "$expected_tree" = "$(git rev-parse "${split_commit}^{tree}")" || {
             echo 'subtree split tree does not match the source package' >&2
@@ -201,7 +201,7 @@ jobs:
             echo "$RELEASE_TAG is not reachable from master" >&2
             exit 1
           }
-          split_commit=$(git subtree split --prefix=clients/client-laravel "$source_commit")
+          split_commit=$(python3 .github/scripts/split-php-client.py "$source_commit")
           expected_tree=$(git rev-parse "$source_commit:clients/client-laravel")
           test "$expected_tree" = "$(git rev-parse "${split_commit}^{tree}")" || {
             echo 'subtree split tree does not match the source package' >&2


### PR DESCRIPTION
## Problem

`queen-mq/php-client` listed a third contributor, `claude`, next to the two humans who wrote the package.

The mirror is a `git subtree split` of `clients/client-laravel`, so it inherits the monorepo commit messages verbatim. Eight of its thirty commits carry a `Co-Authored-By: Claude … <noreply@anthropic.com>` trailer, and GitHub credits co-authors in the contributor sidebar.

## Change

`.github/scripts/split-php-client.py` replaces the inline `git subtree split` in both mirror jobs. It splits the subtree, drops the assistant trailers from every message, rebuilds the commits with `git commit-tree`, and verifies the resulting tree still matches `clients/client-laravel`. Only messages change; the published files are identical.

The rewrite is deterministic. The same source commit always produces the same mirror commit, so the mirror stays fast-forwardable and the existing `merge-base --is-ancestor` guard in both jobs keeps working unchanged.

The script uses only stock `git` and `python3`. CI gains no new dependency.

## Already applied out of band

`php-client` master was force-pushed once, `09ac9f16` → `071ab0d5`. All 30 commits are kept and the trees are byte-identical. The repo had one branch, no tags, no forks and no stars at the time, and no Packagist release exists yet.

## Why the monorepo history was left alone

120 commits in this repo carry the same trailer. Rewriting them would move the `clients/client-go/vX.Y.Z` tags onto new commits, which changes the published Go module hashes and breaks the Go checksum database for existing users. The trade-off is that `claude` stays in this repo's contributor sidebar.

## Verification

- [x] `split-php-client.py origin/master` returns `071ab0d5`, which equals the current mirror head, so the first CI run after merge is a no-op fast-forward.
- [x] Two consecutive runs return the same hash (deterministic).
- [x] The same hash is produced independently by `git-filter-repo` with an equivalent message callback.
- [x] All 30 commit trees are byte-identical to the pre-rewrite mirror.
- [x] `git log --format=%B` on the rewritten history contains zero `Co-Authored-By` lines.
- [x] The workflow YAML parses.
- [ ] Confirm the `mirror-main` job succeeds on the first push to `master` that touches `clients/client-laravel`.
- [ ] Confirm the GitHub sidebar on `php-client` drops `claude` once its contributor cache refreshes.