### PR TITLE
chore(github): make alice-viola the code owner of the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for queen
+#
+# Every pull request targeting a protected branch (master) requires an
+# approving review from a code owner. Branch protection on master also
+# restricts merges to the same owner.
+
+* @alice-viola


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` assigning `@alice-viola` as the owner of every path.

Branch protection is now active on `master`:

- pull request required, with 1 approving review
- **require review from Code Owners** enabled
- stale reviews dismissed on new pushes
- review dismissal restricted to `alice-viola`
- push/merge restricted to `alice-viola`
- force pushes and branch deletion blocked
- `enforce_admins` disabled, so org owners keep an emergency bypass

GitHub reads `CODEOWNERS` from the **base branch** of a pull request. Until this
lands on `master`, the code owner requirement has no owners to match and any
collaborator's approval satisfies the review count. Merging this closes that gap.

## Test plan

- [ ] Merge this PR (only `alice-viola` can merge into `master`)
- [ ] Open a throwaway PR against `master` and confirm `@alice-viola` is auto-requested as reviewer
- [ ] Confirm the merge button stays blocked until `alice-viola` approves

https://claude.ai/code/session_01BtragNrELHBxMq2Y9yqw2D