### PR TITLE
fix(php-client): graft the legacy split from the right parent

### DIFF
--- a/.github/scripts/split-php-client.py
+++ b/.github/scripts/split-php-client.py
@@ -53,13 +53,21 @@ def split(prefix, source):
 
 
 def legacy_tip(source):
-    """Last commit that still carried the package at its pre-rename path."""
-    move = git("rev-list", "-1", source, "--", LEGACY_PREFIX).decode().strip()
-    if not move:
-        return None
-    parent = git("rev-parse", move + "^").decode().strip()
-    git("rev-parse", "--verify", parent + ":" + LEGACY_PREFIX)
-    return parent
+    """Newest ancestor of `source` whose tree still carries the pre-rename path.
+
+    Not the rename commit's first parent: that is the branch point. Anything
+    that touched the legacy path on master after the branch was cut arrives
+    through the merge's *second* parent, and taking the first one drops those
+    commits from the graft, so the mirror diverges from history it already has.
+    """
+    for revision in git("rev-list", "--topo-order", source).decode().split():
+        probe = subprocess.run(
+            ("git", "rev-parse", "--verify", "-q", revision + ":" + LEGACY_PREFIX),
+            capture_output=True,
+        )
+        if probe.returncode == 0:
+            return revision
+    return None
 
 
 def rewrite(split_commit, graft=None, rewritten=None):


### PR DESCRIPTION
## The failure

`mirror-main` has been red since #40 merged. Run [33396185067](https://github.com/queen-mq/queen/actions/runs/33396185067) failed with `php-client mirror master diverged from its source subtree`, `SPLIT_COMMIT=8ed66217`. Every later push to `master` fails the same way, and no release can be cut while it does.

## Root cause

`legacy_tip()` resolved the last state of the pre-rename path as `move^`, the rename commit's **first** parent. That is the branch point, `02e1795a`.

`clients/client-laravel` kept receiving commits on `master` after the branch was cut — the pop autopilot work, among others. Those reached the branch through the merge's **second** parent. Taking the first parent rebuilt a legacy history that stopped at the branch point, while the mirror had already been fast-forwarded to `ab0139d8` on the previous `master` push, which includes them. The ancestor guard then refused the push, correctly.

The guard was not wrong. The history handed to it was.

## Fix

The legacy tip is now the newest ancestor of the source commit whose tree still carries `clients/client-laravel`, regardless of which parent it arrived on. That is the state the mirror was actually built from.

## Verification

| | commit | mirror `ab0139d8` an ancestor? |
| --- | --- | --- |
| current `master` | `8ed66217` | no — reproduces the CI failure exactly |
| this branch | `307b1924` | **yes** |

- 38 commits, no `Co-Authored-By` trailers.
- Split tree is byte-identical to `HEAD:clients/client-php`.
- Deterministic: repeated runs give the same hash.

## Follow-up

- [ ] After merge, confirm `mirror-main` goes green and the mirror advances to `307b1924`.
- [ ] Then `clients/client-php/v1.4.0` can be tagged. `supervisor/v0.1.0` is already published and satisfies the release gate.