### PR TITLE
ci(php-client): re-mirror when the mirror tooling changes

### DIFF
--- a/.github/workflows/release-php-client.yml
+++ b/.github/workflows/release-php-client.yml
@@ -6,6 +6,11 @@ on:
       - master
     paths:
       - 'clients/client-php/**'
+      # The tooling that produces the mirror commit is part of what gets
+      # mirrored. Without these, a fix to the split logic never re-runs the
+      # job it fixes, and a stale mirror cannot be repaired by repairing it.
+      - '.github/scripts/split-php-client.py'
+      - '.github/workflows/release-php-client.yml'
     tags:
       - 'clients/client-php/v*'
   workflow_dispatch:


### PR DESCRIPTION
## The deadlock

After #41 merged, `master` carried a correct mirror job and a mirror it could not repair.

`mirror-main` triggers only on pushes touching `clients/client-php/**`. #41 changed `.github/scripts/split-php-client.py` and nothing else, so no run fired. The mirror is still at `ab0139d8`, from before the rename, and the last actual run is the failure on `ae8c3ac2`.

The only push that would have repaired the mirror was exactly the push the filter excluded.

## Change

The tooling that produces the mirror commit now sits in the trigger beside the package:

```yaml
paths:
  - 'clients/client-php/**'
  - '.github/scripts/split-php-client.py'
  - '.github/workflows/release-php-client.yml'
```

## Expected side effect, worth watching

For push events GitHub evaluates the workflow file at the pushed commit. This PR changes `release-php-client.yml`, which the merged file then lists in its own `paths`. Merging it should therefore fire `mirror-main` on that push and advance the mirror to `307b1924`, clearing the deadlock without anyone pushing to the mirror by hand.

That is the expected behaviour, not a verified one. If no run appears on the merge, the fallback is a later push that genuinely touches `clients/client-php/**`.

## State this is meant to reach

| | |
| --- | --- |
| split of `master` | `307b1924` — 38 commits, no co-author trailers, tree identical to `clients/client-php` |
| live mirror head | `ab0139d8` |
| relationship | clean fast-forward, no force push |

`publish-release` requires the mirror to already contain the release commit, so `clients/client-php/v1.4.0` cannot be tagged until this lands and the mirror advances.

## Still open

Whether a `paths` filter also suppresses tag-triggered runs. `release-cli.yml` and `release-supervisor.yml` both avoid the question by filtering on tags alone; this workflow combines `branches`, `paths` and `tags` in one `push` trigger, and a single trigger cannot express "paths for branches, none for tags". Resolving it properly means splitting this into two workflows. Not done here. `workflow_dispatch` accepts an existing tag and ignores push filters, so a release is not blocked on it either way.

## Follow-up

- [ ] Confirm `mirror-main` fires on this merge and the mirror reaches `307b1924`.
- [ ] Then tag `clients/client-php/v1.4.0`. `supervisor/v0.1.0` is published and satisfies the release gate.