### PR TITLE
feat(dashboard): purge DLQ records by criteria

### DIFF
--- a/app/src/api/index.js
+++ b/app/src/api/index.js
@@ -158,6 +158,8 @@ export const consumers = {
 // ============================================
 export const dlq = {
   list: (params, config) => client.get('/api/v1/dlq', { params, ...config }),
+  /** Purge every DLQ entry matching an exact queue and optional consumer group. */
+  purge: (params, config) => client.delete('/api/v1/dlq', { params, ...config }),
   /** Purge one DLQ entry. 200 {success:false} when nothing matched — check it. */
   delete: (partitionId, transactionId, config) =>
     client.delete(addr(partitionId, transactionId), config),

--- a/app/src/views/DeadLetter.vue
+++ b/app/src/views/DeadLetter.vue
@@ -80,6 +80,17 @@
               <option :value="200">200</option>
             </select>
           </div>
+          <div v-if="canAdmin" class="filter-field-col dlq-bulk-action">
+            <label class="label-xs">Bulk cleanup</label>
+            <button
+              class="btn btn-danger"
+              :disabled="!filterQueue.trim() || bulkPurging"
+              :title="filterQueue.trim() ? bulkPurgeButtonTitle : 'Choose a queue before bulk purging'"
+              @click="openBulkPurge"
+            >
+              Purge by criteria
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -265,6 +276,30 @@
     <!-- Detail drawer (teleported to body to avoid transform issues).
          Backdrop before the panel, so DOM order matches paint order. -->
     <Teleport to="body">
+      <div v-if="bulkTarget" class="modal-backdrop" @click.self="closeBulkPurge">
+        <div class="card modal-card">
+          <div class="card-header"><h3>Purge matching DLQ records</h3></div>
+          <div class="card-body">
+            <div v-if="bulkPurgeError" class="panel-err">{{ bulkPurgeError }}</div>
+            <p>
+              This will permanently purge every dead-letter record for queue
+              <strong class="font-mono">{{ bulkTarget.queue }}</strong><template v-if="bulkTarget.consumerGroup">
+                and consumer group <strong class="font-mono">{{ bulkTarget.consumerGroup }}</strong></template>.
+            </p>
+            <p class="dlq-bulk-note">
+              The error breakdown filter is page-only and is not part of this cleanup.
+              This action cannot be undone.
+            </p>
+          </div>
+          <div class="modal-foot">
+            <button class="btn btn-ghost" :disabled="bulkPurging" @click="closeBulkPurge">Cancel</button>
+            <button class="btn btn-danger" :disabled="bulkPurging" @click="purgeByCriteria">
+              {{ bulkPurging ? 'Purging…' : 'Purge all matching records' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
       <div v-if="selectedMsg" class="modal-backdrop" @click="closeDetail"></div>
 
       <div v-if="selectedMsg" class="drawer-panel">
@@ -444,6 +479,9 @@ const serverPaginates = ref(true)
 // which are replaced wholesale on every refresh.
 const deleting = ref(new Set())
 const rowErrors = ref(new Map())
+const bulkTarget = ref(null)
+const bulkPurging = ref(false)
+const bulkPurgeError = ref(null)
 // Rows this session verified as purged (success:true). Cleared on every reload,
 // so a row that comes back is a row the broker still has.
 const purged = ref(new Set())
@@ -524,6 +562,11 @@ const isDeleting = (msg) => deleting.value.has(msgKey(msg))
 const rowError = (msg) => rowErrors.value.get(msgKey(msg)) || null
 
 const canAdmin = computed(() => can('queueAdmin'))
+const bulkPurgeButtonTitle = computed(() => (
+  filterGroup.value.trim()
+    ? `Purge all DLQ records for ${filterQueue.value.trim()} and consumer group ${filterGroup.value.trim()}`
+    : `Purge all DLQ records for ${filterQueue.value.trim()}`
+))
 
 // ---------------------------------------------------------------------------
 // Failure breakdown — the page's only summary, and the table's filter
@@ -717,6 +760,50 @@ const purge = async (msg) => {
   }
 }
 
+const openBulkPurge = () => {
+  if (!canAdmin.value) return
+  const queue = filterQueue.value.trim()
+  if (!queue) return
+  bulkPurgeError.value = null
+  bulkTarget.value = {
+    queue,
+    consumerGroup: filterGroup.value.trim() || null,
+  }
+}
+
+const closeBulkPurge = () => {
+  if (bulkPurging.value) return
+  bulkTarget.value = null
+  bulkPurgeError.value = null
+}
+
+const purgeByCriteria = async () => {
+  if (!bulkTarget.value || bulkPurging.value) return
+  const target = { ...bulkTarget.value }
+  const params = { queue: target.queue }
+  if (target.consumerGroup) params.consumerGroup = target.consumerGroup
+  bulkPurging.value = true
+  bulkPurgeError.value = null
+  try {
+    const res = await dlq.purge(params)
+    if (res.data?.success !== true || !Number.isInteger(res.data?.deleted)) {
+      throw new Error(res.data?.message || 'The broker did not confirm the bulk purge.')
+    }
+    const deleted = res.data.deleted
+    bulkTarget.value = null
+    page.value = 1
+    errorFilter.value = null
+    await fetchMessages()
+    notifySuccess(
+      deleted === 1 ? 'Purged 1 DLQ record' : `Purged ${formatNumber(deleted)} DLQ records`,
+    )
+  } catch (err) {
+    bulkPurgeError.value = describeApiError(err)
+  } finally {
+    bulkPurging.value = false
+  }
+}
+
 // One shared ticker for the whole app (paused while the tab is hidden) instead
 // of a private setInterval: under the proxy every poll is metered.
 useRefresh(fetchMessages, { auto: true })
@@ -733,6 +820,8 @@ fetchMessages()
 /* Queue names here are dotted and long (`connect.newsletter.sendgrid`), so the
    picker gets more room than the 220px the shared filter column allows. */
 .filter-field-wide { flex-basis: 240px; max-width: 300px; }
+.dlq-bulk-action { flex: 0 0 auto; }
+.dlq-bulk-note { margin-top: 12px; color: var(--text-low); font-size: 12px; }
 
 /* --- Failure breakdown -----------------------------------------------------
    The page's summary, so it is sized like a strip and not like a panel: a 6px

--- a/proxy/src/routes.rs
+++ b/proxy/src/routes.rs
@@ -222,6 +222,9 @@ pub fn classify(method: &axum::http::Method, path: &str) -> RouteClass {
     if p.starts_with("/api/v1/messages/") && *m == Method::DELETE {
         return RouteClass::QueueAdmin;
     }
+    if p == "/api/v1/dlq" && *m == Method::DELETE {
+        return RouteClass::QueueAdmin;
+    }
     if p.starts_with("/api/v1/consumer-groups") && (*m == Method::DELETE || *m == Method::POST) {
         return RouteClass::QueueAdmin;
     }
@@ -430,6 +433,11 @@ mod tests {
             classify(&Method::DELETE, "/api/v1/resources/queues/orders"),
             RouteClass::QueueAdmin
         );
+        assert_eq!(
+            classify(&Method::DELETE, "/api/v1/dlq"),
+            RouteClass::QueueAdmin
+        );
+        assert_eq!(classify(&Method::GET, "/api/v1/dlq"), RouteClass::Read);
         assert_eq!(
             classify(&Method::GET, "/api/v1/resources/queues"),
             RouteClass::Read

--- a/server/sql/procedures/016_messages.sql
+++ b/server/sql/procedures/016_messages.sql
@@ -55,3 +55,38 @@ $$;
 -- (list_messages_v1 / get_dlq_messages_v1 are granted by 010_log_admin, which
 --  owns the live definitions; get_message_v1 no longer exists.)
 GRANT EXECUTE ON FUNCTION queen.delete_message_v1(UUID, TEXT) TO PUBLIC;
+
+-- ============================================================================
+-- queen.purge_dlq_v1: Delete dead-letter snapshots by queue criteria
+-- ============================================================================
+-- A queue is mandatory by signature. Tenant is part of the join predicate so
+-- the same queue name in another tenant is never touched. Consumer group is an
+-- optional additional exact-match criterion.
+CREATE OR REPLACE FUNCTION queen.purge_dlq_v1(
+    p_tenant_id UUID,
+    p_queue TEXT,
+    p_consumer_group TEXT DEFAULT NULL
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_deleted BIGINT;
+BEGIN
+    WITH deleted AS (
+        DELETE FROM queen.log_dlq d
+        USING queen.log_partitions p, queen.queues q
+        WHERE d.partition_id = p.id
+          AND p.queue_id = q.id
+          AND q.tenant_id = p_tenant_id
+          AND q.name = p_queue
+          AND (p_consumer_group IS NULL OR d.consumer_group = p_consumer_group)
+        RETURNING d.id
+    )
+    SELECT count(*) INTO v_deleted FROM deleted;
+
+    RETURN v_deleted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION queen.purge_dlq_v1(UUID, TEXT, TEXT) TO PUBLIC;

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -393,6 +393,9 @@ pub fn route_access_level(method: &Method, path: &str) -> AccessLevel {
     if m == "DELETE" && path.starts_with("/api/v1/resources/queues/") {
         return Admin;
     }
+    if m == "DELETE" && path == "/api/v1/dlq" {
+        return Admin;
+    }
     if path == "/api/v1/stats/refresh" {
         return Admin;
     }
@@ -794,6 +797,18 @@ mod tests {
         assert_eq!(
             route_access_level(&Method::GET, "/api/v1/pop/queue/orders"),
             AccessLevel::ReadWrite
+        );
+    }
+
+    #[test]
+    fn bulk_dlq_purge_requires_admin_access() {
+        assert_eq!(
+            route_access_level(&Method::DELETE, "/api/v1/dlq"),
+            AccessLevel::Admin
+        );
+        assert_eq!(
+            route_access_level(&Method::GET, "/api/v1/dlq"),
+            AccessLevel::ReadOnly
         );
     }
 }

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1172,6 +1172,24 @@ pub async fn delete_message(
         .unwrap_or(false))
 }
 
+// Purge dead-letter snapshots for one queue in one tenant, optionally narrowed
+// to a consumer group. The queue is deliberately mandatory at the HTTP layer:
+// there is no tenant-wide form of this destructive operation.
+pub async fn purge_dlq(
+    client: &deadpool_postgres::Client,
+    tenant: &str,
+    queue: &str,
+    consumer_group: Option<&str>,
+) -> Result<i64, tokio_postgres::Error> {
+    client
+        .query_one(
+            "SELECT queen.purge_dlq_v1($1::text::uuid, $2, $3)",
+            &[&tenant, &queue, &consumer_group],
+        )
+        .await
+        .map(|row| row.get(0))
+}
+
 // ------------------------------------------------------------------- traces
 // All four trace SPs are engine-agnostic (queen.message_traces keyed by
 // transaction_id) — no blob decode. record_trace_v1 is log-aware

--- a/server/src/handlers/messages.rs
+++ b/server/src/handlers/messages.rs
@@ -619,6 +619,62 @@ pub async fn handle_dlq(
     json(StatusCode::OK, v.to_string())
 }
 
+// ------------------------------------------------------------ DELETE /api/v1/dlq
+// Purge DLQ snapshots by exact queue name, optionally narrowed to an exact
+// consumer group. Queue is required so an omitted query parameter can never
+// become a tenant-wide delete. The SQL function repeats the tenant boundary;
+// queue names alone are not globally unique.
+pub async fn handle_purge_dlq(
+    State(st): State<Arc<AppState>>,
+    Extension(tenant): Extension<crate::tenant::Tenant>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    let queue = match params.get("queue").filter(|value| !value.is_empty()) {
+        Some(queue) => queue,
+        None => {
+            return json(
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({
+                    "success": false,
+                    "error": "queue is required",
+                    "message": "Bulk DLQ purge requires an exact queue name",
+                })
+                .to_string(),
+            )
+        }
+    };
+    let consumer_group = params
+        .get("consumerGroup")
+        .filter(|value| !value.is_empty())
+        .map(String::as_str);
+
+    let client = match st.pool.get().await {
+        Ok(c) => c,
+        Err(_) => {
+            return json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "{\"error\":\"pool\"}".to_string(),
+            )
+        }
+    };
+    match db::purge_dlq(&client, tenant.as_str(), queue, consumer_group).await {
+        Ok(deleted) => json(
+            StatusCode::OK,
+            serde_json::json!({
+                "success": true,
+                "deleted": deleted,
+                "queue": queue,
+                "consumerGroup": consumer_group,
+            })
+            .to_string(),
+        ),
+        Err(e) => json(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json_err("bulk dlq purge failed: ", &e),
+        ),
+    }
+}
+
 // Walk a get_dlq_messages_v1 result and replace every encrypted `data` envelope
 // with its plaintext, flagging the row with isEncrypted so the client can tell
 // a decrypted payload from one that was never encrypted. A payload that does

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1093,7 +1093,10 @@ async fn main() {
             "/api/v1/messages/:partitionId/:transactionId/retry",
             post(handlers::handle_retry_message),
         )
-        .route("/api/v1/dlq", get(handlers::handle_dlq))
+        .route(
+            "/api/v1/dlq",
+            get(handlers::handle_dlq).delete(handlers::handle_purge_dlq),
+        )
         .route("/api/v1/traces", post(handlers::handle_record_trace))
         .route("/api/v1/traces/names", get(handlers::handle_trace_names))
         .route(


### PR DESCRIPTION
The DLQ page only allowed operators to purge one message at a time, making cleanup impractical when one queue accumulated many failed records. Admins can now choose an exact queue, optionally narrow it to a consumer group, review those criteria in a confirmation modal, and purge every matching DLQ record in one operation.

The new `DELETE /api/v1/dlq` endpoint requires a queue, enforces admin access at both the proxy and broker, and scopes the SQL delete by tenant. The error breakdown remains a page-only display filter and the confirmation states that it is not part of the purge criteria.

This PR is stacked on #43 because the DLQ view changes build on that branch's drawer and formatting updates.

Validation:
- `npm test` (23 passed)
- `npm run build`
- `cargo test bulk_dlq_purge_requires_admin_access --lib`
- `cargo check --bin queen`
- `cargo test routes::tests::classes` in `proxy`
- Disposable PostgreSQL test covering exact queue matching, optional consumer-group matching, and cross-tenant isolation
- `git diff --check`
