### PR TITLE
Add cell operator user management

### DIFF
--- a/app/src/api/client.js
+++ b/app/src/api/client.js
@@ -31,7 +31,8 @@ const isJsonApiPath = (url = '') => url.startsWith('/api/') || url === '/health'
 // QUEEN_PROXY_SHARED_HOSTS), so sending it changes nothing on a per-cluster
 // hostname or broker-direct.
 const isClusterScoped = (url = '') =>
-  url.startsWith('/api/v1/') || url.startsWith('/api/console/') || url === '/health'
+  url.startsWith('/api/v1/') || url.startsWith('/api/console/') ||
+  url.startsWith('/api/operator/') || url === '/health'
 
 // ---------------------------------------------------------------------------
 // Request: one place, and only one, attaches the acting cluster.

--- a/app/src/api/index.js
+++ b/app/src/api/index.js
@@ -186,6 +186,15 @@ export const system = {
 // Never render one of these numbers without saying it covers the whole cell.
 // ============================================
 export const operator = {
+  /** Users and cluster grants for every tenant represented on the acting cell. */
+  listUsers: (config) => client.get('/api/operator/users', config),
+  createUser: (body, config) => client.post('/api/operator/users', body, config),
+  updateUser: (userId, body, config) =>
+    client.patch(`/api/operator/users/${encodeURIComponent(userId)}`, body, config),
+  setUserRole: (userId, clusterId, role, config) =>
+    client.put(`/api/operator/users/${encodeURIComponent(userId)}/roles/${encodeURIComponent(clusterId)}`, { role }, config),
+  removeUserRole: (userId, clusterId, config) =>
+    client.delete(`/api/operator/users/${encodeURIComponent(userId)}/roles/${encodeURIComponent(clusterId)}`, config),
   /** Cell-wide broker status (every tenant on this cell). */
   getStatus: (params, config) => client.get('/api/v1/status', { params, ...config }),
   /** Disk file-buffer state for the cell. */

--- a/app/src/components/Sidebar.vue
+++ b/app/src/components/Sidebar.vue
@@ -161,6 +161,7 @@ const navGroups = computed(() => {
     const nav = r.meta?.nav
     if (!nav) continue
     if (!can(r.meta.requires || 'read')) continue
+    if (r.meta.proxyOnly && standalone.value) continue
     if (!groups.has(nav.group)) groups.set(nav.group, [])
     groups.get(nav.group).push({
       name: r.meta.title,
@@ -190,6 +191,7 @@ const icons = {
   analytics: AnalyticsIcon,
   dlq: DlqIcon,
   system: SystemIcon,
+  users: UsersIcon,
 }
 
 function DashboardIcon(p) { return h('svg', { ...p, fill:'none', viewBox:'0 0 24 24', stroke:'currentColor', 'stroke-width':'1.6' }, [h('rect',{x:'3',y:'3',width:'7',height:'9',rx:'1.5'}),h('rect',{x:'14',y:'3',width:'7',height:'5',rx:'1.5'}),h('rect',{x:'14',y:'12',width:'7',height:'9',rx:'1.5'}),h('rect',{x:'3',y:'16',width:'7',height:'5',rx:'1.5'})]) }
@@ -203,6 +205,7 @@ function MessagesIcon(p) { return h('svg', { ...p, fill:'none', viewBox:'0 0 24 
 function TracesIcon(p) { return h('svg', { ...p, fill:'none', viewBox:'0 0 24 24', stroke:'currentColor', 'stroke-width':'1.6' }, [h('path',{d:'M3 6h6M11 10h8M7 14h10M3 18h6'}),h('circle',{cx:'9',cy:'6',r:'1.6',fill:'currentColor'}),h('circle',{cx:'19',cy:'10',r:'1.6',fill:'currentColor'}),h('circle',{cx:'17',cy:'14',r:'1.6',fill:'currentColor'}),h('circle',{cx:'9',cy:'18',r:'1.6',fill:'currentColor'})]) }
 function AnalyticsIcon(p) { return h('svg', { ...p, fill:'none', viewBox:'0 0 24 24', stroke:'currentColor', 'stroke-width':'1.6' }, [h('path',{d:'M4 20V10M10 20V4M16 20v-8M22 20H2'})]) }
 function SystemIcon(p) { return h('svg', { ...p, fill:'none', viewBox:'0 0 24 24', stroke:'currentColor', 'stroke-width':'1.6' }, [h('rect',{x:'3',y:'4',width:'18',height:'6',rx:'1.6'}),h('rect',{x:'3',y:'14',width:'18',height:'6',rx:'1.6'}),h('circle',{cx:'7',cy:'7',r:'.9',fill:'currentColor'}),h('circle',{cx:'7',cy:'17',r:'.9',fill:'currentColor'})]) }
+function UsersIcon(p) { return h('svg', { ...p, fill:'none', viewBox:'0 0 24 24', stroke:'currentColor', 'stroke-width':'1.6', 'stroke-linecap':'round', 'stroke-linejoin':'round' }, [h('circle',{cx:'9',cy:'8',r:'3'}),h('path',{d:'M3.5 20c0-3.3 2.5-6 5.5-6s5.5 2.7 5.5 6'}),h('path',{d:'M17 8v6M14 11h6'})]) }
 function DlqIcon(p) { return h('svg', { ...p, fill:'none', viewBox:'0 0 24 24', stroke:'currentColor', 'stroke-width':'1.6' }, [h('path',{d:'M5 7h14l-1.2 11.2a2 2 0 01-2 1.8H8.2a2 2 0 01-2-1.8L5 7Z'}),h('path',{d:'M9 4h6v3H9z'})]) }
 </script>
 

--- a/app/src/router/index.js
+++ b/app/src/router/index.js
@@ -1,7 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import { can, ensureIdentity } from '@/stores/identity'
+import { can, ensureIdentity, useIdentity } from '@/stores/identity'
 import { notifyError } from '@/stores/ui'
+
+const { standalone } = useIdentity()
 
 // Route meta is the declaration of what a page needs and what it is about.
 // Nothing else may decide either — the sidebar and the guard both read it.
@@ -15,6 +17,7 @@ import { notifyError } from '@/stores/ui'
 //              number is the lie class this shell exists to prevent.
 //   nav      : { group, order } to appear in the sidebar. Omit to stay
 //              reachable by URL but out of the nav.
+//   proxyOnly: the broker-direct dashboard has no pxdb-backed account store.
 const routes = [
   {
     path: '/',
@@ -136,6 +139,16 @@ const routes = [
     }
   },
   {
+    path: '/users',
+    name: 'Users',
+    component: () => import('@/views/Users.vue'),
+    meta: {
+      title: 'Users', subtitle: 'Cell-level: user accounts and cluster access',
+      requires: 'operator', scope: 'cell', proxyOnly: true,
+      nav: { group: 'Cell', icon: 'users', order: 2 },
+    }
+  },
+  {
     path: '/:pathMatch(.*)*',
     name: 'NotFound',
     component: () => import('@/components/NotFound.vue'),
@@ -162,6 +175,11 @@ router.beforeEach(async (to) => {
     // Boot failed (network / 5xx). App.vue renders the failure; let the
     // navigation through so it has something to render into.
     return true
+  }
+
+  if (to.meta.proxyOnly && standalone.value) {
+    notifyError('User accounts are managed by queen-proxy and are unavailable in broker-direct mode', 'Not available')
+    return { path: '/', replace: true }
   }
 
   const requires = to.meta.requires || 'read'

--- a/app/src/views/Users.vue
+++ b/app/src/views/Users.vue
@@ -1,0 +1,503 @@
+<template>
+  <div class="view-container">
+    <div class="scope-strip scope-strip-cell">
+      <span class="chip chip-warn"><span class="dot"></span>cell · operator</span>
+      <span class="scope-text">
+        user accounts and cluster access for <strong>cell {{ cellSlug }}</strong>
+        <span class="scope-sep">·</span>
+        every tenant represented on this cell
+      </span>
+    </div>
+
+    <div v-if="error" class="status-banner banner-bad view-banner">
+      <span>
+        <strong>Could not load users</strong> · {{ describeApiError(error) }}
+        <template v-if="loaded"> · showing the last list that loaded</template>
+      </span>
+    </div>
+
+    <div class="users-summary">
+      <div class="stat">
+        <div class="stat-label">Users</div>
+        <div class="stat-value font-mono">{{ users.length }}</div>
+        <div class="stat-foot">accounts in cell tenants</div>
+      </div>
+      <div class="stat">
+        <div class="stat-label">Tenants</div>
+        <div class="stat-value font-mono">{{ tenants.length }}</div>
+        <div class="stat-foot">represented on this cell</div>
+      </div>
+      <div class="stat">
+        <div class="stat-label">Access grants</div>
+        <div class="stat-value font-mono">{{ grantCount }}</div>
+        <div class="stat-foot">roles on cell clusters</div>
+      </div>
+    </div>
+
+    <div class="card users-filters">
+      <div class="card-body users-toolbar">
+        <div class="filter-field-col users-search">
+          <label class="label-xs" for="users-search">Search</label>
+          <input id="users-search" v-model="search" class="input" placeholder="Name, email or tenant" />
+        </div>
+        <div class="filter-field-col users-tenant-filter">
+          <label class="label-xs" for="users-tenant">Tenant</label>
+          <select id="users-tenant" v-model="tenantFilter" class="input">
+            <option value="">All tenants</option>
+            <option v-for="tenant in tenants" :key="tenant.id" :value="tenant.id">
+              {{ tenant.slug }}
+            </option>
+          </select>
+        </div>
+        <span class="scope-fill"></span>
+        <button class="btn btn-primary" :disabled="!tenants.length" @click="openCreate">
+          Add user
+        </button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h3>Cell users</h3>
+        <span class="card-sub">{{ filteredUsers.length }} shown</span>
+        <span v-if="loading" class="muted">refreshing…</span>
+      </div>
+      <div class="table-container">
+        <table v-if="filteredUsers.length" class="table">
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Tenant</th>
+              <th>Sign-in</th>
+              <th>Cluster access</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="user in filteredUsers" :key="user.id">
+              <td>
+                <div class="users-name">{{ user.name || 'Unnamed user' }}</div>
+                <div class="users-email">{{ user.email }}</div>
+                <div class="users-created">created {{ formatDate(user.created_at) }}</div>
+                <div class="users-last-login">
+                  {{ user.last_login_at ? `last sign-in ${formatDateTime(user.last_login_at)}` : 'never signed in' }}
+                </div>
+              </td>
+              <td><span class="font-mono">{{ user.tenant_slug }}</span></td>
+              <td>
+                <span class="chip chip-mute">{{ user.has_local_password ? 'local' : 'OAuth' }}</span>
+                <span v-if="user.is_operator" class="chip chip-warn users-operator">operator</span>
+              </td>
+              <td>
+                <div v-if="user.roles.length" class="users-role-list">
+                  <span v-for="grant in user.roles" :key="grant.cluster_id" class="chip chip-mute">
+                    <span class="font-mono">{{ grant.cluster_slug }}</span> · {{ grant.role }}
+                  </span>
+                </div>
+                <span v-else class="users-no-access">No access on this cell</span>
+              </td>
+              <td class="right">
+                <button class="btn btn-ghost" @click="openEdit(user)">Edit</button>
+                <button class="btn btn-ghost" @click="openAccess(user)">Manage access</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div v-else-if="loading && !loaded" class="users-loading">
+          <div v-for="i in 5" :key="i" class="skeleton" />
+        </div>
+        <div v-else class="empty-state">
+          <svg class="empty-state-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <circle cx="9" cy="8" r="3" />
+            <path stroke-linecap="round" d="M3.5 20c0-3.3 2.5-6 5.5-6s5.5 2.7 5.5 6M17 8v6M14 11h6" />
+          </svg>
+          <h3>{{ users.length ? 'No users match these filters' : 'No users on this cell' }}</h3>
+          <p>{{ users.length ? 'Try another email or tenant.' : 'Create the first account and grant its initial cluster role.' }}</p>
+          <button v-if="!users.length && tenants.length" class="btn btn-primary" @click="openCreate">Add user</button>
+        </div>
+      </div>
+    </div>
+
+    <Teleport to="body">
+      <div v-if="showCreate" class="modal-backdrop" @click.self="closeCreate">
+        <form class="card modal-card" @submit.prevent="createUser">
+          <div class="card-header"><h3>Add user</h3></div>
+          <div class="card-body users-form">
+            <div v-if="createError" class="panel-err">{{ createError }}</div>
+
+            <label class="users-field">
+              <span class="label-xs">Tenant</span>
+              <select v-model="createForm.tenant_id" class="input" required>
+                <option v-for="tenant in tenants" :key="tenant.id" :value="tenant.id">
+                  {{ tenant.slug }} · {{ tenant.name }}
+                </option>
+              </select>
+            </label>
+            <label class="users-field">
+              <span class="label-xs">Name</span>
+              <input v-model.trim="createForm.name" class="input" maxlength="160" autocomplete="off" required placeholder="Ada Lovelace" />
+            </label>
+            <label class="users-field">
+              <span class="label-xs">Email</span>
+              <input v-model.trim="createForm.email" class="input" type="email" autocomplete="off" required placeholder="user@example.com" />
+            </label>
+            <label class="users-field">
+              <span class="label-xs">Sign-in method</span>
+              <select v-model="createForm.provider" class="input">
+                <option value="google">Google OAuth</option>
+                <option value="github">GitHub OAuth</option>
+                <option value="local">Local password</option>
+              </select>
+            </label>
+            <label v-if="createForm.provider === 'local'" class="users-field">
+              <span class="label-xs">Initial password</span>
+              <input v-model="createForm.password" class="input" type="password" minlength="12" maxlength="128" autocomplete="new-password" required />
+              <span class="users-help">At least 12 characters.</span>
+            </label>
+            <div v-else class="users-help users-oauth-note">
+              The first verified {{ providerLabel }} login with this email links the identity to this account.
+            </div>
+            <div class="users-form-grid">
+              <label class="users-field">
+                <span class="label-xs">Initial cluster</span>
+                <select v-model="createForm.cluster_id" class="input" required>
+                  <option v-for="cluster in createClusters" :key="cluster.id" :value="cluster.id">
+                    {{ cluster.slug }}
+                  </option>
+                </select>
+              </label>
+              <label class="users-field">
+                <span class="label-xs">Role</span>
+                <select v-model="createForm.role" class="input">
+                  <option v-for="role in roles" :key="role" :value="role">{{ role }}</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div class="modal-foot">
+            <button type="button" class="btn btn-ghost" @click="closeCreate">Cancel</button>
+            <button type="submit" class="btn btn-primary" :disabled="creating || !createForm.cluster_id">
+              {{ creating ? 'Creating…' : 'Create user' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div v-if="editedUser" class="modal-backdrop" @click.self="closeEdit">
+        <form class="card modal-card" @submit.prevent="updateUser">
+          <div class="card-header"><h3>Edit user</h3></div>
+          <div class="card-body users-form">
+            <div v-if="editError" class="panel-err">{{ editError }}</div>
+            <div class="users-modal-email">{{ editedUser.email }} · {{ editedUser.tenant_slug }}</div>
+            <label class="users-field">
+              <span class="label-xs">Name</span>
+              <input v-model.trim="editName" class="input" maxlength="160" autocomplete="off" required />
+            </label>
+          </div>
+          <div class="modal-foot">
+            <button type="button" class="btn btn-ghost" @click="closeEdit">Cancel</button>
+            <button type="submit" class="btn btn-primary" :disabled="editing || !editName.trim()">
+              {{ editing ? 'Saving…' : 'Save name' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div v-if="managedUser" class="modal-backdrop" @click.self="managedUser = null">
+        <div class="card modal-card users-access-modal">
+          <div class="card-header">
+            <div>
+              <h3>Manage cluster access</h3>
+              <div class="users-modal-email">{{ managedUser.email }} · {{ managedUser.tenant_slug }}</div>
+            </div>
+          </div>
+          <div class="card-body">
+            <div v-if="accessError" class="panel-err">{{ accessError }}</div>
+            <div class="users-access-list">
+              <div v-for="cluster in managedClusters" :key="cluster.id" class="users-access-row">
+                <div class="users-cluster">
+                  <span class="font-mono">{{ cluster.slug }}</span>
+                  <span class="chip chip-mute">{{ cluster.status }}</span>
+                </div>
+                <select v-model="roleDrafts[cluster.id]" class="input users-role-select">
+                  <option value="">No access</option>
+                  <option v-for="role in roles" :key="role" :value="role">{{ role }}</option>
+                </select>
+                <button
+                  class="btn"
+                  :class="{ 'btn-danger': !roleDrafts[cluster.id] && currentRole(cluster.id) }"
+                  :disabled="savingCluster === cluster.id || roleDrafts[cluster.id] === currentRole(cluster.id)"
+                  @click="saveRole(cluster)"
+                >
+                  {{ savingCluster === cluster.id ? 'Saving…' : roleDrafts[cluster.id] ? 'Save' : 'Remove' }}
+                </button>
+              </div>
+            </div>
+            <p class="users-help users-access-note">
+              A cluster must keep at least one admin. Removing access here affects only this cell.
+            </p>
+          </div>
+          <div class="modal-foot">
+            <button class="btn btn-ghost" @click="managedUser = null">Close</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+
+import { operator, describeApiError } from '@/api'
+import { useRefresh } from '@/composables/useRefresh'
+import { useToast } from '@/composables/useToast'
+import { useIdentity } from '@/stores/identity'
+
+const roles = ['admin', 'producer', 'consumer', 'viewer']
+const { actingCellSlug } = useIdentity()
+const { notifySuccess } = useToast()
+
+const users = ref([])
+const tenants = ref([])
+const clusters = ref([])
+const responseCell = ref(null)
+const loading = ref(false)
+const loaded = ref(false)
+const error = ref(null)
+const search = ref('')
+const tenantFilter = ref('')
+
+const cellSlug = computed(() => responseCell.value?.slug || actingCellSlug.value || 'unknown')
+const grantCount = computed(() => users.value.reduce((sum, user) => sum + user.roles.length, 0))
+const filteredUsers = computed(() => {
+  const query = search.value.trim().toLowerCase()
+  return users.value.filter(user => {
+    if (tenantFilter.value && user.tenant_id !== tenantFilter.value) return false
+    if (!query) return true
+    return (user.name || '').toLowerCase().includes(query) ||
+      user.email.toLowerCase().includes(query) || user.tenant_slug.toLowerCase().includes(query)
+  })
+})
+
+async function loadUsers() {
+  if (loading.value) return
+  loading.value = true
+  error.value = null
+  try {
+    const { data } = await operator.listUsers()
+    users.value = data.users || []
+    tenants.value = data.tenants || []
+    clusters.value = data.clusters || []
+    responseCell.value = data.cell || null
+    loaded.value = true
+    if (tenantFilter.value && !tenants.value.some(t => t.id === tenantFilter.value)) tenantFilter.value = ''
+  } catch (err) {
+    error.value = err
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadUsers)
+useRefresh(loadUsers)
+
+const showCreate = ref(false)
+const creating = ref(false)
+const createError = ref('')
+const createForm = reactive({
+  tenant_id: '', name: '', email: '', provider: 'google', password: '', cluster_id: '', role: 'viewer',
+})
+const createClusters = computed(() => clusters.value.filter(c => c.tenant_id === createForm.tenant_id))
+const providerLabel = computed(() => createForm.provider === 'github' ? 'GitHub' : 'Google')
+
+watch(() => createForm.tenant_id, () => {
+  if (!createClusters.value.some(c => c.id === createForm.cluster_id)) {
+    createForm.cluster_id = createClusters.value[0]?.id || ''
+  }
+})
+
+function openCreate() {
+  const tenant = tenants.value.find(t => t.id === tenantFilter.value) || tenants.value[0]
+  createForm.tenant_id = tenant?.id || ''
+  createForm.name = ''
+  createForm.email = ''
+  createForm.provider = 'google'
+  createForm.password = ''
+  createForm.role = 'viewer'
+  createForm.cluster_id = clusters.value.find(c => c.tenant_id === createForm.tenant_id)?.id || ''
+  createError.value = ''
+  showCreate.value = true
+}
+
+function closeCreate() {
+  if (creating.value) return
+  showCreate.value = false
+  createError.value = ''
+}
+
+async function createUser() {
+  if (creating.value) return
+  creating.value = true
+  createError.value = ''
+  try {
+    await operator.createUser({
+      tenant_id: createForm.tenant_id,
+      name: createForm.name,
+      email: createForm.email,
+      provider: createForm.provider,
+      password: createForm.provider === 'local' ? createForm.password : null,
+      cluster_id: createForm.cluster_id,
+      role: createForm.role,
+    })
+    showCreate.value = false
+    notifySuccess(`Created ${createForm.email}`)
+    await loadUsers()
+  } catch (err) {
+    createError.value = describeApiError(err)
+  } finally {
+    creating.value = false
+  }
+}
+
+const editedUser = ref(null)
+const editName = ref('')
+const editing = ref(false)
+const editError = ref('')
+
+function openEdit(user) {
+  editedUser.value = user
+  editName.value = user.name || ''
+  editError.value = ''
+}
+
+function closeEdit() {
+  if (editing.value) return
+  editedUser.value = null
+  editError.value = ''
+}
+
+async function updateUser() {
+  if (!editedUser.value || editing.value || !editName.value.trim()) return
+  const userId = editedUser.value.id
+  editing.value = true
+  editError.value = ''
+  try {
+    await operator.updateUser(userId, { name: editName.value })
+    notifySuccess(`Updated ${editName.value}`)
+    editedUser.value = null
+    await loadUsers()
+  } catch (err) {
+    editError.value = describeApiError(err)
+  } finally {
+    editing.value = false
+  }
+}
+
+const managedUser = ref(null)
+const roleDrafts = ref({})
+const savingCluster = ref(null)
+const accessError = ref('')
+const managedClusters = computed(() =>
+  managedUser.value ? clusters.value.filter(c => c.tenant_id === managedUser.value.tenant_id) : []
+)
+
+function openAccess(user) {
+  managedUser.value = user
+  roleDrafts.value = Object.fromEntries(
+    clusters.value
+      .filter(c => c.tenant_id === user.tenant_id)
+      .map(c => [c.id, user.roles.find(r => r.cluster_id === c.id)?.role || ''])
+  )
+  accessError.value = ''
+}
+
+function currentRole(clusterId) {
+  return managedUser.value?.roles.find(role => role.cluster_id === clusterId)?.role || ''
+}
+
+async function saveRole(cluster) {
+  if (!managedUser.value || savingCluster.value) return
+  const userId = managedUser.value.id
+  const nextRole = roleDrafts.value[cluster.id]
+  savingCluster.value = cluster.id
+  accessError.value = ''
+  try {
+    if (nextRole) await operator.setUserRole(userId, cluster.id, nextRole)
+    else await operator.removeUserRole(userId, cluster.id)
+    notifySuccess(nextRole ? `Access on ${cluster.slug} set to ${nextRole}` : `Access on ${cluster.slug} removed`)
+    await loadUsers()
+    const refreshed = users.value.find(user => user.id === userId)
+    if (refreshed) openAccess(refreshed)
+  } catch (err) {
+    accessError.value = describeApiError(err)
+    roleDrafts.value[cluster.id] = currentRole(cluster.id)
+  } finally {
+    savingCluster.value = null
+  }
+}
+
+function formatDate(value) {
+  if (!value) return 'unknown'
+  return new Date(value).toLocaleDateString()
+}
+
+function formatDateTime(value) {
+  if (!value) return 'unknown'
+  return new Date(value).toLocaleString()
+}
+</script>
+
+<style scoped>
+.users-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.users-filters { margin-bottom: 12px; }
+.users-toolbar { display: flex; align-items: end; gap: 10px; }
+.users-search { flex: 1 1 320px; max-width: 460px; }
+.users-tenant-filter { flex: 0 1 220px; }
+.users-name { font-weight: 550; }
+.users-email { margin-top: 1px; color: var(--text-mid); font-size: 12px; }
+.users-created, .users-last-login, .users-modal-email { margin-top: 2px; color: var(--text-low); font-size: 11px; }
+.users-operator { margin-left: 5px; }
+.users-role-list { display: flex; flex-wrap: wrap; gap: 5px; }
+.users-no-access { color: var(--text-low); font-style: italic; }
+.users-loading { display: grid; gap: 8px; padding: 16px; }
+.users-loading .skeleton { height: 34px; }
+.users-form { display: grid; gap: 14px; }
+.users-field { display: grid; gap: 6px; }
+.users-form-grid { display: grid; grid-template-columns: 1fr 140px; gap: 10px; }
+.users-help { color: var(--text-low); font-size: 11.5px; line-height: 1.45; }
+.users-oauth-note { padding: 9px 10px; border: 1px solid var(--bd); border-radius: var(--r-control); background: var(--ink-3); }
+.users-access-modal { max-width: 620px; }
+.users-access-list { display: grid; gap: 8px; }
+.users-access-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 150px 76px;
+  gap: 8px;
+  align-items: center;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--bd-soft);
+}
+.users-access-row:last-child { padding-bottom: 0; border-bottom: 0; }
+.users-cluster { display: flex; align-items: center; gap: 7px; min-width: 0; }
+.users-role-select { min-width: 0; }
+.users-access-note { margin-top: 14px; }
+.right { text-align: right; }
+@media (max-width: 720px) {
+  .users-summary { grid-template-columns: 1fr; }
+  .users-toolbar { align-items: stretch; flex-direction: column; }
+  .users-search, .users-tenant-filter { max-width: none; width: 100%; }
+  .users-form-grid { grid-template-columns: 1fr; }
+  .users-access-row { grid-template-columns: 1fr 1fr; }
+  .users-access-row .btn { grid-column: 2; justify-self: end; }
+}
+</style>

--- a/proxy/CONTRACTS.md
+++ b/proxy/CONTRACTS.md
@@ -65,8 +65,9 @@ agents work inside this crate. **Read both before writing code.**
   set_limit_override in 003; revoke_session, sweep_revoked_tokens,
   grant_cluster_role, revoke_cluster_role, bootstrap_tenant,
   rollup_usage_days, cluster_month_msgs, emit_outbox in 004;
-  prune_usage_minutes in 005) — SECURITY DEFINER-style discipline: validate,
-  write, append `operations` row, `pg_notify('queen_proxy_inval', cluster_id)`.
+  prune_usage_minutes in 005; set_user_name in 010; record_user_login in 011)
+  — SECURITY DEFINER-style discipline: validate, write, append `operations`
+  row, `pg_notify('queen_proxy_inval', cluster_id)`.
   `bootstrap_tenant` is the one-call onboarding path (tenant + cluster + admin
   user + role + first api key, returning the plaintext key once).
 - Broker-facing constants: header `x-queen-tenant` (config::TENANT_HEADER),

--- a/proxy/migrations/010_user_name.sql
+++ b/proxy/migrations/010_user_name.sql
@@ -1,0 +1,56 @@
+-- Optional human-readable name for proxy users. Existing accounts stay valid
+-- with NULL; operator-created accounts require a name at the HTTP boundary.
+ALTER TABLE queen_proxy.users
+    ADD COLUMN IF NOT EXISTS name TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'users_name_valid'
+           AND conrelid = 'queen_proxy.users'::regclass
+    ) THEN
+        ALTER TABLE queen_proxy.users
+            ADD CONSTRAINT users_name_valid
+            CHECK (name IS NULL OR (btrim(name) <> '' AND char_length(name) <= 160));
+    END IF;
+END;
+$$;
+
+-- Keep profile writes behind the same control-plane function boundary as
+-- user creation and role management. The caller adds its own user-attributed
+-- audit row; this function records the canonical data mutation.
+CREATE OR REPLACE FUNCTION queen_proxy.set_user_name(
+    p_user UUID,
+    p_name TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_tenant_id UUID;
+    v_old_name  TEXT;
+    v_name      TEXT;
+BEGIN
+    v_name := btrim(p_name);
+    IF v_name IS NULL OR v_name = '' OR char_length(v_name) > 160 THEN
+        RAISE EXCEPTION 'set_user_name: name must contain 1 to 160 characters';
+    END IF;
+
+    SELECT tenant_id, name
+      INTO v_tenant_id, v_old_name
+      FROM queen_proxy.users
+     WHERE id = p_user;
+    IF v_tenant_id IS NULL THEN
+        RAISE EXCEPTION 'set_user_name: unknown user %', p_user;
+    END IF;
+
+    UPDATE queen_proxy.users SET name = v_name WHERE id = p_user;
+
+    PERFORM queen_proxy.record_operation(
+        v_tenant_id, NULL, 'control_plane', p_user,
+        'user_name_changed', p_user::text,
+        jsonb_build_object('old_name', v_old_name, 'name', v_name)
+    );
+END;
+$$;

--- a/proxy/migrations/011_user_last_login.sql
+++ b/proxy/migrations/011_user_last_login.sql
@@ -1,0 +1,34 @@
+-- Last successful interactive authentication. NULL means the account has
+-- never completed a login since this field was introduced.
+ALTER TABLE queen_proxy.users
+    ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ;
+
+-- Update the account and append the existing `login` audit event atomically.
+-- Login remains best-effort from the HTTP handler: an audit/control-plane
+-- outage must not invalidate a session that was already authenticated.
+CREATE OR REPLACE FUNCTION queen_proxy.record_user_login(
+    p_user UUID
+) RETURNS TIMESTAMPTZ
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_tenant_id UUID;
+    v_login_at  TIMESTAMPTZ;
+BEGIN
+    UPDATE queen_proxy.users
+       SET last_login_at = now()
+     WHERE id = p_user
+     RETURNING tenant_id, last_login_at INTO v_tenant_id, v_login_at;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'record_user_login: unknown user %', p_user;
+    END IF;
+
+    PERFORM queen_proxy.record_operation(
+        v_tenant_id, NULL, 'user', p_user,
+        'login', p_user::text, '{}'::jsonb
+    );
+
+    RETURN v_login_at;
+END;
+$$;

--- a/proxy/scripts/seed-dev.sql
+++ b/proxy/scripts/seed-dev.sql
@@ -87,6 +87,11 @@ BEGIN
         RAISE NOTICE 'set dev password for dev@localhost (devpass)';
     END IF;
 
+    -- Human-readable fixture name for the operator user management page.
+    UPDATE queen_proxy.users
+       SET name = 'Dev Operator'
+     WHERE id = v_user AND name IS NULL;
+
     -- cell 'local' -----------------------------------------------------
     -- Infrastructure row, not tenant business data -- no queen_proxy.*
     -- function creates cells (see 001_init.sql's comment on the cells

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -1026,6 +1026,13 @@ impl Keys {
         role
     }
 
+    /// Drop one cached positive role after a control-plane role mutation.
+    /// Revocations must take effect on the next request rather than after the
+    /// normal short TTL expires.
+    pub fn invalidate_role(&self, user_id: Uuid, cluster_id: Uuid) {
+        self.role_cache.lock().unwrap().remove(&(user_id, cluster_id));
+    }
+
     /// Does this user hold the operator bit (`queen_proxy.users.is_operator`)?
     /// Cached `ROLE_TTL`, both answers.
     ///

--- a/proxy/src/db.rs
+++ b/proxy/src/db.rs
@@ -93,6 +93,8 @@ pub fn migrations() -> Vec<(&'static str, &'static str)> {
         ("007_tenant_delete", include_str!("../migrations/007_tenant_delete.sql")),
         ("008_bootstrap_password", include_str!("../migrations/008_bootstrap_password.sql")),
         ("009_default_families", include_str!("../migrations/009_default_families.sql")),
+        ("010_user_name", include_str!("../migrations/010_user_name.sql")),
+        ("011_user_last_login", include_str!("../migrations/011_user_last_login.sql")),
     ]
 }
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -16,6 +16,7 @@ mod limits;
 mod meter;
 mod oauth;
 mod obs;
+mod operator;
 mod pgtls;
 mod registry;
 mod routes;
@@ -281,6 +282,7 @@ async fn async_main(worker_threads: usize) {
         .route("/.well-known/jwks.json", get(jwks))
         .nest("/auth", oauth::router())
         .nest("/api/console", console::router())
+        .nest("/api/operator", operator::router())
         // three routes, not a bare wildcard: /console/*path alone does not
         // match "/console/" (empty remainder) under axum 0.7's matchit
         .route("/console", get(console::spa))

--- a/proxy/src/oauth.rs
+++ b/proxy/src/oauth.rs
@@ -177,8 +177,8 @@ async fn verify_local(st: &St, email: &str, password: &str) -> Option<UserRef> {
 // sessions
 // ---------------------------------------------------------------------------
 
-/// Mint a session JWT, record a `login` op, and redirect to `next` with the
-/// session cookie set.
+/// Mint a session JWT, record the successful login, and redirect to `next`
+/// with the session cookie set.
 async fn establish_session(st: &St, headers: &HeaderMap, user: UserRef, next: &str) -> Response {
     let token = match st.keys.mint_user_jwt(user.user_id, SESSION_ROLE, None, st.cfg.jwt_ttl_s) {
         Ok(t) => t,
@@ -192,9 +192,27 @@ async fn establish_session(st: &St, headers: &HeaderMap, user: UserRef, next: &s
             return err_500("session token could not be minted");
         }
     };
-    record_op(st, user.tenant_id, user.user_id, "login", Some(user.user_id.to_string()), json!({})).await;
+    record_login(st, user.user_id).await;
     let cookie = session_cookie(st, headers, &token);
     redirect(StatusCode::SEE_OTHER, next, Some(&cookie))
+}
+
+/// Persist the account's latest successful authentication and its audit event
+/// in one database function call. This is best-effort for the same reason the
+/// previous login audit was: a temporary pxdb failure must not discard a valid
+/// session after password/OAuth verification and token minting succeeded.
+async fn record_login(st: &St, user_id: Uuid) {
+    let Some(pool) = st.db.as_ref() else { return };
+    let Ok(client) = pool.get().await else { return };
+    if let Err(e) = client
+        .execute(
+            "SELECT queen_proxy.record_user_login($1::text::uuid)",
+            &[&user_id.to_string()],
+        )
+        .await
+    {
+        tracing::warn!(target: "oauth", err = %e, "record_user_login failed (non-fatal)");
+    }
 }
 
 /// Log out: deny-list the presented session, then clear the cookie.

--- a/proxy/src/operator.rs
+++ b/proxy/src/operator.rs
@@ -1,0 +1,830 @@
+//! Cell-operator account management (`/api/operator/*`).
+//!
+//! These routes are served directly by the proxy because users, tenants and
+//! cluster roles live in pxdb rather than in the broker. Every request first
+//! resolves the acting cluster and requires a live human operator. The acting
+//! cluster supplies the cell boundary: callers can only see tenants with a
+//! cluster on that cell and can only change roles on those clusters.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio_postgres::error::SqlState;
+use uuid::Uuid;
+
+use crate::errors;
+use crate::state::{ClusterCtx, Principal, St};
+
+const VALID_ROLES: [&str; 4] = ["admin", "producer", "consumer", "viewer"];
+const VALID_PROVIDERS: [&str; 3] = ["local", "google", "github"];
+
+pub fn router() -> Router<St> {
+    Router::new()
+        .route("/users", get(list_users).post(create_user))
+        .route("/users/:user_id", axum::routing::patch(update_user))
+        .route(
+            "/users/:user_id/roles/:cluster_id",
+            axum::routing::put(set_role).delete(remove_role),
+        )
+}
+
+/// Resolve the selected cluster and require the live operator capability.
+/// Refusals deliberately use the gateway's operator-route 404 contract so a
+/// tenant principal cannot use this surface to discover privileged features.
+async fn operator_ctx(
+    st: &St,
+    headers: &HeaderMap,
+    path: &str,
+) -> Result<(Arc<ClusterCtx>, Uuid), Response> {
+    if !st.cfg.operator_enabled {
+        return Err(route_blocked());
+    }
+    if st.db.is_none() {
+        return Err(errors::json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not_configured",
+            "operator user management requires pxdb",
+        ));
+    }
+
+    let route = crate::acting::resolve_route(st, headers).await?;
+    let (ctx, principal) = match route {
+        crate::acting::Route::Fixed(ctx) => {
+            let principal = crate::acting::authenticate_for(st, headers, &ctx).await?;
+            (ctx, principal)
+        }
+        crate::acting::Route::FromCredential => {
+            crate::acting::resolve_from_credential(st, headers).await?
+        }
+        crate::acting::Route::UnknownHost => {
+            return Err(crate::acting::unknown_host_refusal(st, headers).await)
+        }
+    };
+
+    match principal {
+        Principal::User {
+            user_id,
+            operator: true,
+            ..
+        } => {
+            crate::acting::note_operator_access(user_id, &ctx.slug, path);
+            Ok((ctx, user_id))
+        }
+        Principal::User { .. } | Principal::ApiKey { .. } => Err(route_blocked()),
+    }
+}
+
+fn route_blocked() -> Response {
+    errors::err_404(errors::CODE_ROUTE_BLOCKED, "not available")
+}
+
+async fn cell_for(
+    client: &tokio_postgres::Client,
+    ctx: &ClusterCtx,
+) -> Result<(String, String), Response> {
+    let row = client
+        .query_opt(
+            "SELECT ce.id::text, ce.slug
+               FROM queen_proxy.clusters c
+               JOIN queen_proxy.cells ce ON ce.id = c.cell_id
+              WHERE c.id = $1::text::uuid",
+            &[&ctx.cluster_id.to_string()],
+        )
+        .await
+        .map_err(|e| {
+            tracing::warn!(target: "operator", err = %e, "cell lookup failed");
+            errors::err_502("cell lookup failed")
+        })?;
+    row.map(|r| (r.get(0), r.get(1)))
+        .ok_or_else(|| errors::err_421("acting cluster no longer exists"))
+}
+
+async fn list_users(State(st): State<St>, headers: HeaderMap) -> Response {
+    let (ctx, _actor_id) = match operator_ctx(&st, &headers, "/api/operator/users").await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let pool = st.db.as_ref().expect("operator_ctx guarantees pxdb");
+    let client = match pool.get().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "list_users: pool.get failed");
+            return errors::err_502("pxdb unavailable");
+        }
+    };
+    let (cell_id, cell_slug) = match cell_for(&client, &ctx).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let tenant_rows = match client
+        .query(
+            "SELECT DISTINCT t.id::text, t.slug, t.name
+               FROM queen_proxy.tenants t
+               JOIN queen_proxy.clusters c ON c.tenant_id = t.id
+              WHERE c.cell_id = $1::text::uuid
+              ORDER BY t.slug",
+            &[&cell_id],
+        )
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "tenant list failed");
+            return errors::err_502("tenant list failed");
+        }
+    };
+    let tenants: Vec<Value> = tenant_rows
+        .iter()
+        .map(|r| json!({ "id": r.get::<_, String>(0), "slug": r.get::<_, String>(1), "name": r.get::<_, String>(2) }))
+        .collect();
+
+    let cluster_rows = match client
+        .query(
+            "SELECT id::text, slug, tenant_id::text, status
+               FROM queen_proxy.clusters
+              WHERE cell_id = $1::text::uuid
+              ORDER BY slug",
+            &[&cell_id],
+        )
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "cluster list failed");
+            return errors::err_502("cluster list failed");
+        }
+    };
+    let clusters: Vec<Value> = cluster_rows
+        .iter()
+        .map(|r| {
+            json!({
+                "id": r.get::<_, String>(0),
+                "slug": r.get::<_, String>(1),
+                "tenant_id": r.get::<_, String>(2),
+                "status": r.get::<_, String>(3),
+            })
+        })
+        .collect();
+
+    let user_rows = match client
+        .query(
+            "SELECT u.id::text, u.email, u.name, u.tenant_id::text, t.slug,
+                    u.is_operator, (u.password_hash IS NOT NULL),
+                    to_char(u.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'),
+                    to_char(u.last_login_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')
+               FROM queen_proxy.users u
+               JOIN queen_proxy.tenants t ON t.id = u.tenant_id
+              WHERE EXISTS (
+                    SELECT 1 FROM queen_proxy.clusters c
+                     WHERE c.tenant_id = u.tenant_id
+                       AND c.cell_id = $1::text::uuid)
+              ORDER BY t.slug, u.email",
+            &[&cell_id],
+        )
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "user list failed");
+            return errors::err_502("user list failed");
+        }
+    };
+
+    let mut user_index = HashMap::new();
+    let mut users: Vec<Value> = user_rows
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let id = r.get::<_, String>(0);
+            user_index.insert(id.clone(), i);
+            json!({
+                "id": id,
+                "email": r.get::<_, String>(1),
+                "name": r.get::<_, Option<String>>(2),
+                "tenant_id": r.get::<_, String>(3),
+                "tenant_slug": r.get::<_, String>(4),
+                "is_operator": r.get::<_, bool>(5),
+                "has_local_password": r.get::<_, bool>(6),
+                "created_at": r.get::<_, String>(7),
+                "last_login_at": r.get::<_, Option<String>>(8),
+                "roles": [],
+            })
+        })
+        .collect();
+
+    let role_rows = match client
+        .query(
+            "SELECT cr.user_id::text, c.id::text, c.slug, cr.role
+               FROM queen_proxy.cluster_roles cr
+               JOIN queen_proxy.clusters c ON c.id = cr.cluster_id
+              WHERE c.cell_id = $1::text::uuid
+              ORDER BY c.slug",
+            &[&cell_id],
+        )
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "role list failed");
+            return errors::err_502("role list failed");
+        }
+    };
+    for row in role_rows {
+        let user_id = row.get::<_, String>(0);
+        let Some(index) = user_index.get(&user_id).copied() else {
+            continue;
+        };
+        let role = json!({
+            "cluster_id": row.get::<_, String>(1),
+            "cluster_slug": row.get::<_, String>(2),
+            "role": row.get::<_, String>(3),
+        });
+        users[index]["roles"]
+            .as_array_mut()
+            .expect("roles is an array")
+            .push(role);
+    }
+
+    json_ok(json!({
+        "cell": { "id": cell_id, "slug": cell_slug },
+        "tenants": tenants,
+        "clusters": clusters,
+        "users": users,
+    }))
+}
+
+#[derive(Deserialize)]
+struct CreateUserReq {
+    tenant_id: String,
+    email: String,
+    name: String,
+    provider: String,
+    password: Option<String>,
+    cluster_id: String,
+    role: String,
+}
+
+async fn create_user(
+    State(st): State<St>,
+    headers: HeaderMap,
+    Json(body): Json<CreateUserReq>,
+) -> Response {
+    let (ctx, actor_id) = match operator_ctx(&st, &headers, "/api/operator/users").await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let tenant_id = match parse_uuid(&body.tenant_id, "tenant_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let cluster_id = match parse_uuid(&body.cluster_id, "cluster_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let email = match validate_email(&body.email) {
+        Ok(v) => v,
+        Err(msg) => return err_400(msg),
+    };
+    let name = match validate_name(&body.name) {
+        Ok(v) => v,
+        Err(msg) => return err_400(msg),
+    };
+    let provider = match validate_provider(&body.provider) {
+        Ok(v) => v,
+        Err(msg) => return err_400(msg),
+    };
+    let role = match validate_role(&body.role) {
+        Ok(v) => v,
+        Err(msg) => return err_400(msg),
+    };
+    let password = match validate_password(&provider, body.password.as_deref()) {
+        Ok(v) => v,
+        Err(msg) => return err_400(msg),
+    };
+
+    let password_hash = if let Some(password) = password {
+        match tokio::task::spawn_blocking(move || bcrypt::hash(password, bcrypt::DEFAULT_COST))
+            .await
+        {
+            Ok(Ok(hash)) => Some(hash),
+            Ok(Err(e)) => {
+                tracing::warn!(target: "operator", err = %e, "password hashing failed");
+                return err_500("password could not be hashed");
+            }
+            Err(e) => {
+                tracing::warn!(target: "operator", err = %e, "password hashing task failed");
+                return err_500("password could not be hashed");
+            }
+        }
+    } else {
+        None
+    };
+
+    let pool = st.db.as_ref().expect("operator_ctx guarantees pxdb");
+    let mut client = match pool.get().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "create_user: pool.get failed");
+            return errors::err_502("pxdb unavailable");
+        }
+    };
+    let (cell_id, _) = match cell_for(&client, &ctx).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let tx = match client.transaction().await {
+        Ok(tx) => tx,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "create_user: transaction failed");
+            return errors::err_502("user creation failed");
+        }
+    };
+
+    let scoped = match tx
+        .query_opt(
+            "SELECT 1
+               FROM queen_proxy.clusters
+              WHERE id = $1::text::uuid
+                AND tenant_id = $2::text::uuid
+                AND cell_id = $3::text::uuid",
+            &[&cluster_id.to_string(), &tenant_id.to_string(), &cell_id],
+        )
+        .await
+    {
+        Ok(row) => row.is_some(),
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "create_user: scope check failed");
+            return errors::err_502("cluster lookup failed");
+        }
+    };
+    if !scoped {
+        return errors::err_404("not_found", "tenant and cluster are not on this cell");
+    }
+
+    let user_row = match tx
+        .query_one(
+            "SELECT queen_proxy.create_user($1::text::uuid, $2, $3, $4)::text",
+            &[&tenant_id.to_string(), &email, &password_hash, &provider],
+        )
+        .await
+    {
+        Ok(row) => row,
+        Err(e) if e.code() == Some(&SqlState::UNIQUE_VIOLATION) => {
+            return errors::json_error(
+                StatusCode::CONFLICT,
+                "conflict",
+                "a user with this email already exists",
+            )
+        }
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "create_user failed");
+            return errors::err_502("user creation failed");
+        }
+    };
+    let user_id = user_row.get::<_, String>(0);
+
+    if let Err(e) = tx
+        .execute(
+            "SELECT queen_proxy.set_user_name($1::text::uuid, $2)",
+            &[&user_id, &name],
+        )
+        .await
+    {
+        tracing::warn!(target: "operator", err = %e, "initial user name failed");
+        return errors::err_502("user name could not be saved");
+    }
+
+    if let Err(e) = tx
+        .execute(
+            "SELECT queen_proxy.grant_cluster_role($1::text::uuid, $2, $3)",
+            &[&cluster_id.to_string(), &email, &role],
+        )
+        .await
+    {
+        tracing::warn!(target: "operator", err = %e, "initial role grant failed");
+        return errors::err_502("initial role grant failed");
+    }
+    let meta =
+        json!({ "email": email, "name": name, "provider": provider, "role": role }).to_string();
+    if let Err(e) = tx
+        .execute(
+            "SELECT queen_proxy.record_operation($1::text::uuid, $2::text::uuid, 'user', $3::text::uuid, 'operator_user_created', $4, $5::text::jsonb)",
+            &[&tenant_id.to_string(), &cluster_id.to_string(), &actor_id.to_string(), &user_id, &meta],
+        )
+        .await
+    {
+        tracing::warn!(target: "operator", err = %e, "operator user audit failed");
+        return errors::err_502("user creation audit failed");
+    }
+    if let Err(e) = tx.commit().await {
+        tracing::warn!(target: "operator", err = %e, "create_user commit failed");
+        return errors::err_502("user creation failed");
+    }
+
+    json_created(json!({
+        "id": user_id,
+        "email": email,
+        "name": name,
+        "tenant_id": tenant_id,
+        "cluster_id": cluster_id,
+        "role": role,
+    }))
+}
+
+#[derive(Deserialize)]
+struct UpdateUserReq {
+    name: String,
+}
+
+async fn update_user(
+    State(st): State<St>,
+    headers: HeaderMap,
+    Path(user_id): Path<String>,
+    Json(body): Json<UpdateUserReq>,
+) -> Response {
+    let (ctx, actor_id) = match operator_ctx(&st, &headers, "/api/operator/users/:id").await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let user_id = match parse_uuid(&user_id, "user_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let name = match validate_name(&body.name) {
+        Ok(v) => v,
+        Err(msg) => return err_400(msg),
+    };
+
+    let pool = st.db.as_ref().expect("operator_ctx guarantees pxdb");
+    let mut client = match pool.get().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "update_user: pool.get failed");
+            return errors::err_502("pxdb unavailable");
+        }
+    };
+    let (cell_id, _) = match cell_for(&client, &ctx).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let tx = match client.transaction().await {
+        Ok(tx) => tx,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "update_user: transaction failed");
+            return errors::err_502("user update failed");
+        }
+    };
+    let target = match tx
+        .query_opt(
+            "SELECT u.tenant_id::text, u.name
+               FROM queen_proxy.users u
+              WHERE u.id = $1::text::uuid
+                AND EXISTS (
+                    SELECT 1 FROM queen_proxy.clusters c
+                     WHERE c.tenant_id = u.tenant_id
+                       AND c.cell_id = $2::text::uuid)",
+            &[&user_id.to_string(), &cell_id],
+        )
+        .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => return errors::err_404("not_found", "user is not on this cell"),
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "update_user: scope lookup failed");
+            return errors::err_502("user lookup failed");
+        }
+    };
+    let tenant_id = target.get::<_, String>(0);
+    let old_name = target.get::<_, Option<String>>(1);
+    if old_name.as_deref() == Some(name.as_str()) {
+        return json_ok(json!({ "ok": true, "id": user_id, "name": name }));
+    }
+
+    if let Err(e) = tx
+        .execute(
+            "SELECT queen_proxy.set_user_name($1::text::uuid, $2)",
+            &[&user_id.to_string(), &name],
+        )
+        .await
+    {
+        tracing::warn!(target: "operator", err = %e, "set_user_name failed");
+        return errors::err_502("user update failed");
+    }
+    let meta = json!({ "old_name": old_name, "name": name }).to_string();
+    if let Err(e) = tx
+        .execute(
+            "SELECT queen_proxy.record_operation($1::text::uuid, NULL, 'user', $2::text::uuid, 'operator_user_updated', $3, $4::text::jsonb)",
+            &[&tenant_id, &actor_id.to_string(), &user_id.to_string(), &meta],
+        )
+        .await
+    {
+        tracing::warn!(target: "operator", err = %e, "operator user update audit failed");
+        return errors::err_502("user update audit failed");
+    }
+    if let Err(e) = tx.commit().await {
+        tracing::warn!(target: "operator", err = %e, "update_user commit failed");
+        return errors::err_502("user update failed");
+    }
+
+    json_ok(json!({ "ok": true, "id": user_id, "name": name }))
+}
+
+#[derive(Deserialize)]
+struct SetRoleReq {
+    role: String,
+}
+
+async fn set_role(
+    State(st): State<St>,
+    headers: HeaderMap,
+    Path((user_id, cluster_id)): Path<(String, String)>,
+    Json(body): Json<SetRoleReq>,
+) -> Response {
+    let role = match validate_role(&body.role) {
+        Ok(v) => v,
+        Err(msg) => return err_400(msg),
+    };
+    change_role(&st, &headers, &user_id, &cluster_id, Some(role)).await
+}
+
+async fn remove_role(
+    State(st): State<St>,
+    headers: HeaderMap,
+    Path((user_id, cluster_id)): Path<(String, String)>,
+) -> Response {
+    change_role(&st, &headers, &user_id, &cluster_id, None).await
+}
+
+async fn change_role(
+    st: &St,
+    headers: &HeaderMap,
+    user_id_raw: &str,
+    cluster_id_raw: &str,
+    new_role: Option<String>,
+) -> Response {
+    let (ctx, actor_id) =
+        match operator_ctx(st, headers, "/api/operator/users/:id/roles/:cluster").await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+    let user_id = match parse_uuid(user_id_raw, "user_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let cluster_id = match parse_uuid(cluster_id_raw, "cluster_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let pool = st.db.as_ref().expect("operator_ctx guarantees pxdb");
+    let mut client = match pool.get().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "change_role: pool.get failed");
+            return errors::err_502("pxdb unavailable");
+        }
+    };
+    let (cell_id, _) = match cell_for(&client, &ctx).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let tx = match client.transaction().await {
+        Ok(tx) => tx,
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "change_role: transaction failed");
+            return errors::err_502("role change failed");
+        }
+    };
+    if let Err(e) = tx
+        .batch_execute("LOCK TABLE queen_proxy.cluster_roles IN SHARE ROW EXCLUSIVE MODE")
+        .await
+    {
+        tracing::warn!(target: "operator", err = %e, "role lock failed");
+        return errors::err_502("role change failed");
+    }
+
+    let standing = match tx
+        .query_opt(
+            "SELECT u.email, u.tenant_id::text, cr.role,
+                    (SELECT count(*) FROM queen_proxy.cluster_roles admins
+                      WHERE admins.cluster_id = c.id AND admins.role = 'admin')
+               FROM queen_proxy.users u
+               JOIN queen_proxy.clusters c
+                 ON c.id = $2::text::uuid AND c.tenant_id = u.tenant_id
+               LEFT JOIN queen_proxy.cluster_roles cr
+                 ON cr.user_id = u.id AND cr.cluster_id = c.id
+              WHERE u.id = $1::text::uuid
+                AND c.cell_id = $3::text::uuid",
+            &[&user_id.to_string(), &cluster_id.to_string(), &cell_id],
+        )
+        .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return errors::err_404(
+                "not_found",
+                "user and cluster are not on this cell or tenant",
+            )
+        }
+        Err(e) => {
+            tracing::warn!(target: "operator", err = %e, "role standing lookup failed");
+            return errors::err_502("role lookup failed");
+        }
+    };
+    let email = standing.get::<_, String>(0);
+    let tenant_id = standing.get::<_, String>(1);
+    let current_role = standing.get::<_, Option<String>>(2);
+    let admin_count = standing.get::<_, i64>(3);
+
+    if new_role.is_none() && current_role.is_none() {
+        return errors::err_404("not_found", "user has no access to this cluster");
+    }
+    if would_orphan_admins(current_role.as_deref(), admin_count, new_role.as_deref()) {
+        return err_400("cannot remove or demote the last admin of this cluster");
+    }
+
+    let action = if let Some(role) = new_role.as_deref() {
+        if let Err(e) = tx
+            .execute(
+                "SELECT queen_proxy.grant_cluster_role($1::text::uuid, $2, $3)",
+                &[&cluster_id.to_string(), &email, &role],
+            )
+            .await
+        {
+            tracing::warn!(target: "operator", err = %e, "role grant failed");
+            return errors::err_502("role grant failed");
+        }
+        "operator_role_granted"
+    } else {
+        if let Err(e) = tx
+            .execute(
+                "SELECT queen_proxy.revoke_cluster_role($1::text::uuid, $2)",
+                &[&cluster_id.to_string(), &email],
+            )
+            .await
+        {
+            tracing::warn!(target: "operator", err = %e, "role revocation failed");
+            return errors::err_502("role revocation failed");
+        }
+        "operator_role_revoked"
+    };
+
+    let meta =
+        json!({ "email": email, "role": new_role, "previous_role": current_role }).to_string();
+    if let Err(e) = tx
+        .execute(
+            "SELECT queen_proxy.record_operation($1::text::uuid, $2::text::uuid, 'user', $3::text::uuid, $4, $5, $6::text::jsonb)",
+            &[&tenant_id, &cluster_id.to_string(), &actor_id.to_string(), &action, &user_id.to_string(), &meta],
+        )
+        .await
+    {
+        tracing::warn!(target: "operator", err = %e, "operator role audit failed");
+        return errors::err_502("role change audit failed");
+    }
+    if let Err(e) = tx.commit().await {
+        tracing::warn!(target: "operator", err = %e, "role change commit failed");
+        return errors::err_502("role change failed");
+    }
+
+    st.keys.invalidate_role(user_id, cluster_id);
+    json_ok(json!({ "ok": true, "role": new_role }))
+}
+
+fn parse_uuid(raw: &str, field: &str) -> Result<Uuid, Response> {
+    Uuid::parse_str(raw).map_err(|_| err_400(&format!("{field} must be a UUID")))
+}
+
+fn validate_email(raw: &str) -> Result<String, &'static str> {
+    let email = raw.trim().to_lowercase();
+    if email.is_empty() || !email.contains('@') || email.len() > 320 {
+        return Err("email must be a valid address");
+    }
+    Ok(email)
+}
+
+fn validate_name(raw: &str) -> Result<String, &'static str> {
+    let name = raw.trim();
+    if name.is_empty() {
+        return Err("name is required");
+    }
+    if name.chars().count() > 160 {
+        return Err("name must be at most 160 characters");
+    }
+    Ok(name.to_string())
+}
+
+fn validate_provider(raw: &str) -> Result<String, &'static str> {
+    let provider = raw.trim().to_lowercase();
+    if !VALID_PROVIDERS.contains(&provider.as_str()) {
+        return Err("provider must be one of local, google, github");
+    }
+    Ok(provider)
+}
+
+fn validate_role(raw: &str) -> Result<String, &'static str> {
+    let role = raw.trim().to_lowercase();
+    if !VALID_ROLES.contains(&role.as_str()) {
+        return Err("role must be one of admin, producer, consumer, viewer");
+    }
+    Ok(role)
+}
+
+fn validate_password(provider: &str, raw: Option<&str>) -> Result<Option<String>, &'static str> {
+    if provider != "local" {
+        if raw.is_some_and(|p| !p.is_empty()) {
+            return Err("password is only accepted for local users");
+        }
+        return Ok(None);
+    }
+    let password = raw.ok_or("local users require a password")?;
+    if password.len() < 12 {
+        return Err("password must be at least 12 characters");
+    }
+    if password.len() > 128 {
+        return Err("password must be at most 128 characters");
+    }
+    Ok(Some(password.to_string()))
+}
+
+fn would_orphan_admins(
+    current_role: Option<&str>,
+    admin_count: i64,
+    new_role: Option<&str>,
+) -> bool {
+    current_role == Some("admin") && new_role != Some("admin") && admin_count <= 1
+}
+
+fn json_ok(value: Value) -> Response {
+    json_response(StatusCode::OK, value)
+}
+
+fn json_created(value: Value) -> Response {
+    json_response(StatusCode::CREATED, value)
+}
+
+fn json_response(status: StatusCode, value: Value) -> Response {
+    let mut response = (status, value.to_string()).into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    response
+}
+
+fn err_400(message: &str) -> Response {
+    errors::json_error(StatusCode::BAD_REQUEST, "invalid_request", message)
+}
+
+fn err_500(message: &str) -> Response {
+    errors::json_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_validation_normalizes_and_rejects_invalid_values() {
+        assert_eq!(
+            validate_email(" Dev@Example.com ").unwrap(),
+            "dev@example.com"
+        );
+        assert!(validate_email("missing-at").is_err());
+        assert_eq!(validate_name(" Ada Lovelace ").unwrap(), "Ada Lovelace");
+        assert!(validate_name("   ").is_err());
+        assert!(validate_name(&"a".repeat(161)).is_err());
+        assert_eq!(validate_role(" Admin ").unwrap(), "admin");
+        assert!(validate_role("owner").is_err());
+        assert_eq!(validate_provider(" GitHub ").unwrap(), "github");
+        assert!(validate_provider("saml").is_err());
+    }
+
+    #[test]
+    fn local_password_policy_is_provider_aware() {
+        assert!(validate_password("local", None).is_err());
+        assert!(validate_password("local", Some("short")).is_err());
+        assert_eq!(
+            validate_password("local", Some("twelve-chars!")),
+            Ok(Some("twelve-chars!".to_string()))
+        );
+        assert_eq!(validate_password("google", None), Ok(None));
+        assert!(validate_password("google", Some("not-used-here")).is_err());
+    }
+
+    #[test]
+    fn last_admin_guard_only_blocks_orphaning_change() {
+        assert!(would_orphan_admins(Some("admin"), 1, Some("viewer")));
+        assert!(would_orphan_admins(Some("admin"), 1, None));
+        assert!(!would_orphan_admins(Some("admin"), 2, None));
+        assert!(!would_orphan_admins(Some("viewer"), 1, None));
+        assert!(!would_orphan_admins(Some("admin"), 1, Some("admin")));
+    }
+}

--- a/server/webapp/dist/index.html
+++ b/server/webapp/dist/index.html
@@ -24,8 +24,8 @@
       document.documentElement.classList.add('dark');
       document.documentElement.classList.remove('light');
     </script>
-    <script type="module" crossorigin src="/assets/index-jtHKmPmq.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BZ81ygS1.css">
+    <script type="module" crossorigin src="/assets/index-DurAB0s8.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-VA6hnoqi.css">
   </head>
   <body class="antialiased">
     <div id="app"></div>

--- a/webdoc/src/content/docs/deploy/dashboard.mdx
+++ b/webdoc/src/content/docs/deploy/dashboard.mdx
@@ -11,8 +11,10 @@ sourceOfTruth:
   - app/src/router/index.js
   - app/src/stores/identity.js
   - app/src/views/System.vue
+  - app/src/views/Users.vue
   - app/src/views/DeadLetter.vue
   - proxy/src/webapp.rs
+  - proxy/src/operator.rs
 ---
 
 Every broker serves a dashboard on its own port, with nothing to deploy: the built single-page
@@ -35,7 +37,7 @@ so a missing path under `/api/` or `/auth/` still answers a JSON 404 instead of 
 
 ## The views
 
-Every view is tenant-scoped except System, and the exception is labelled on screen.
+Every view is tenant-scoped except System and Users, and both exceptions are labelled on screen.
 
 - **Dashboard**, `/`: the resource overview, namespaces and tasks
 - **Queue Operations**, `/operations`: per-queue throughput, lag and consumer health
@@ -50,6 +52,8 @@ Every view is tenant-scoped except System, and the exception is labelled on scre
   per-row purge
 - **System**, `/system`: cell-level host CPU and memory, worker metrics, PostgreSQL internals,
   the disk spool, the maintenance switch
+- **Users**, `/users`: cell-level accounts for tenants represented on the selected cell, with
+  account creation, latest-login visibility and per-cluster role management; available only behind `queen_proxy`
 
 <Screenshot
   src="dashboard-consumer-groups"
@@ -57,8 +61,8 @@ Every view is tenant-scoped except System, and the exception is labelled on scre
   caption="Five groups keeping pace and two that stopped, separated by the broker's own offsets rather than by inference. The two slow readers here are deliberate."
 />
 
-Three things to know before reading a number off this UI. System covers the whole cell and
-every tenant on it, so a cell figure is not a tenant figure. The dead-letter view inspects and
+Three things to know before reading a number off this UI. System and Users cover the whole cell
+and every tenant on it, so a cell figure or account list is not a tenant figure. The dead-letter view inspects and
 purges: replaying a dead-lettered message is a broker route,
 [`POST /api/v1/messages/:partitionId/:transactionId/retry`](/reference/http/messages-dlq), and
 this console does not call it yet, so purge is the only action on a row. And an unknown is not a
@@ -117,7 +121,8 @@ it, so whoever answers that route is the whole difference between three deployme
 - **Broker-direct, auth on** (`JWT_ENABLED=true`): `401 {"code":"auth_required"}`, and the login
   redirect lands on a terminal static page saying so.
 - **Behind `queen_proxy`**: the proxy's cookie-authenticated session, with real users,
-  per-cluster roles, an operator flag and a login page the broker never sees.
+  per-cluster roles, an operator flag, cell-level user management for live operators, and a
+  login page the broker never sees.
 
 The `standalone` flag hides the cluster selector and the sign-out, because there is nothing to
 switch to and no session to end. Nothing is granted with it: the API was already open to anyone

--- a/webdoc/src/content/docs/reference/multi-tenant/auth.mdx
+++ b/webdoc/src/content/docs/reference/multi-tenant/auth.mdx
@@ -281,7 +281,10 @@ lookup and no way in.
 
 A live operator is `admin` on every cluster on that cell, membership row or not, and is
 the only principal that can open the cell-wide surfaces: broker status, buffer state,
-host and PostgreSQL metrics, maintenance mode, and the Prometheus endpoint. Operator
+host and PostgreSQL metrics, maintenance mode, the Prometheus endpoint, and the proxy-backed
+Users page. That page can create and name local or OAuth-first accounts for tenants represented
+on the selected cell, edit their display names, show their latest successful login, and add, change, or remove their roles on clusters on that cell. It cannot set the
+operator bit. Operator
 access is logged, sampled to one line per minute with a suppressed count, because a
 dashboard polls those routes.
 

--- a/webdoc/src/content/docs/reference/multi-tenant/tenants.mdx
+++ b/webdoc/src/content/docs/reference/multi-tenant/tenants.mdx
@@ -12,6 +12,8 @@ sourceOfTruth:
   - proxy/migrations/003_limit_override.sql
   - proxy/migrations/004_lifecycle.sql
   - proxy/migrations/006_operator.sql
+  - proxy/migrations/010_user_name.sql
+  - proxy/migrations/011_user_last_login.sql
   - proxy/src/auth.rs
   - proxy/src/registry.rs
   - proxy/src/console.rs
@@ -29,7 +31,7 @@ optional.
 | Table | Holds | Lifecycle |
 | --- | --- | --- |
 | `tenants` | The organisation. `slug` (DNS-label shaped, unique), `name`, `status` | `status`, never `DELETE` |
-| `users` | Login identity, scoped to one tenant. `email` globally unique, optional bcrypt `password_hash`, `is_operator` | Cascades with its tenant |
+| `users` | Login identity, scoped to one tenant. Non-unique optional display `name`, globally unique `email`, optional bcrypt `password_hash`, `last_login_at`, `is_operator` | Cascades with its tenant |
 | `identities` | One row per linked provider (`local`, `google`, `github`) per user, with `verified` | Cascades with its user |
 | `plans` | The limit catalog. `code`, `cell_class`, eleven limit columns, `monthly_msgs_quota`, `features` jsonb | Referenced with `RESTRICT` |
 | `cells` | One physical stack. `slug`, `region`, `base_url`, `class`, `cell_secret`, `status`, `capacity_slots`, `used_slots` | Inserted by hand |
@@ -191,6 +193,8 @@ in a form the login path accepts.
 | --- | --- |
 | `create_tenant(slug, name)` → uuid | |
 | `create_user(tenant, email, password_hash, provider)` → uuid | Writes `users` only. It does **not** write `identities`: the OAuth login path is what creates those rows, and local password login does not consult them |
+| `set_user_name(user, name)` | Sets the user's display name and records the change |
+| `record_user_login(user)` → timestamptz | Stores the latest successful local or OAuth login and appends its audit event atomically |
 | `create_cluster(tenant, slug, plan_code, cell_id)` → uuid | `broker_tenant_uuid` comes from the column default |
 | `assign_plan(cluster, plan_code)` | |
 | `set_limit_override(cluster, overrides)` | |


### PR DESCRIPTION
## Summary

Cell operators can inspect cell-wide infrastructure, but they cannot manage the tenant accounts and cluster grants represented on that cell. This adds a protected `/users` operator surface backed by proxy control-plane APIs.

- Create local, Google, or GitHub-first accounts with a non-unique display name and an initial cluster role.
- Edit display names and show account creation plus the latest successful login.
- Add, change, or remove `admin`, `producer`, `consumer`, and `viewer` grants on clusters in the selected cell.
- Prevent removal or demotion of the last cluster administrator.
- Record profile, role, account creation, and login changes in the control-plane audit trail.
- Add migrations for display names and `last_login_at`, plus operator-facing documentation.

## Validation

- `cargo test` — 370 passed, 4 ignored
- `npm test` — 12 passed
- `npm run build`
- `pnpm build`
- `pnpm check:markdown`
- `pnpm check:prose`
- Local end-to-end verification of account listing, name updates, successful-login timestamping, invalid-role rejection, last-admin protection, all four database role values, and duplicate display names
