### PR TITLE
[1/3] Replace Axios with Ky in the dashboard

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -22,7 +22,7 @@ A beautiful, modern dashboard for monitoring and managing Queen message queues.
 - **Tailwind CSS** - Utility-first CSS framework
 - **Chart.js** - Beautiful responsive charts
 - **Vue Router** - Client-side routing
-- **Axios** - HTTP client
+- **Ky** - Fetch-based HTTP client
 
 ## Getting Started
 
@@ -120,7 +120,7 @@ re-implement any of it.
 | Polling | `useAutoRefresh(cb)` from `@/composables/useRefresh` | a private `setInterval` |
 | Cell-level numbers | `operator.*` in `@/api`, and say "cell" on screen | present them as the tenant's |
 
-`x-queen-act-cluster` is attached by the axios request interceptor, once, for
+`x-queen-act-cluster` is attached by the shared HTTP request hook, once, for
 every `/api/v1/*` call. No view sends it.
 
 ## Project Structure
@@ -200,4 +200,3 @@ The app includes several reusable components:
 ## License
 
 Apache 2.0 — see [`../LICENSE.md`](../LICENSE.md).
-

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,8 +8,8 @@
       "name": "queen-dashboard",
       "version": "1.0.0",
       "dependencies": {
-        "axios": "^1.20.0",
         "chart.js": "^4.5.1",
+        "ky": "^2.1.0",
         "vue": "^3.5.42",
         "vue-chartjs": "^5.3.4",
         "vue-json-pretty": "^2.6.0",
@@ -859,18 +859,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -904,24 +892,6 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
-      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.6",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -929,19 +899,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/chart.js": {
@@ -971,18 +928,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
@@ -995,32 +940,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1029,20 +948,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -1069,51 +974,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/estree-walker": {
@@ -1145,42 +1005,6 @@
         }
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1195,64 +1019,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1260,63 +1026,11 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -1326,6 +1040,18 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/ky": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-2.1.0.tgz",
+      "integrity": "sha512-nIKwelw+7qVqKOlX4Eht6GXfEXlDHcdIjyLWV3s119kYt5s+70ayTnYS+0fRNmtgGRRAfqdeWQbh8YizqkS0ng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/lightningcss": {
@@ -1642,36 +1368,6 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -1700,12 +1396,6 @@
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
@@ -1810,15 +1500,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/quansync": {

--- a/app/package.json
+++ b/app/package.json
@@ -10,8 +10,8 @@
     "test": "node --test test/*.test.js"
   },
   "dependencies": {
-    "axios": "^1.20.0",
     "chart.js": "^4.5.1",
+    "ky": "^2.1.0",
     "vue": "^3.5.42",
     "vue-chartjs": "^5.3.4",
     "vue-json-pretty": "^2.6.0",

--- a/app/src/api/client.js
+++ b/app/src/api/client.js
@@ -1,122 +1,17 @@
-import axios from 'axios'
-
+import { createApiClient } from './httpClient'
 import { ApiError, CODE_ROUTE_BLOCKED } from './errors'
 import { actingClusterHeader, redirectToLogin } from '@/stores/identity'
 import { reportApiFailure, reportApiSuccess } from '@/stores/ui'
 
 // Same origin under the proxy; VITE_API_BASE_URL only exists for the
 // broker-direct debugging mode (see vite.config.js).
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
-
-const client = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 30000,
-  // The httpOnly `queen_session` cookie authenticates /api/v1/* and
-  // /api/console/* directly. No token dance, no Authorization header.
-  withCredentials: true,
-  headers: {
-    'Content-Type': 'application/json'
-  }
+const client = createApiClient({
+  apiBaseUrl: import.meta.env.VITE_API_BASE_URL || '',
+  getActingClusterHeader: actingClusterHeader,
+  redirectToLogin,
+  reportApiFailure,
+  reportApiSuccess,
 })
-
-// Paths that answer JSON, never HTML. `/metrics/prometheus` is deliberately
-// out: it is the one gateway surface whose success body is text.
-const isJsonApiPath = (url = '') => url.startsWith('/api/') || url === '/health'
-
-/** Paths whose cluster attribution is set by the act-as header. */
-// `/api/console/*` is here for the SHARED-HOST console (one URL fronting many
-// clusters), where the Host names no cluster and the header is the only thing
-// that can — proxy/src/acting.rs `resolve_route_console`. Everywhere else the
-// console deliberately IGNORES the header (it is read only on a host listed in
-// QUEEN_PROXY_SHARED_HOSTS), so sending it changes nothing on a per-cluster
-// hostname or broker-direct.
-const isClusterScoped = (url = '') =>
-  url.startsWith('/api/v1/') || url.startsWith('/api/console/') ||
-  url.startsWith('/api/operator/') || url === '/health'
-
-// ---------------------------------------------------------------------------
-// Request: one place, and only one, attaches the acting cluster.
-// ---------------------------------------------------------------------------
-client.interceptors.request.use(
-  (config) => {
-    if (isClusterScoped(config.url || '')) {
-      const act = actingClusterHeader()
-      if (act) config.headers[act.name] = act.value
-    }
-    return config
-  },
-  (error) => Promise.reject(error)
-)
-
-// ---------------------------------------------------------------------------
-// Response: preserve status + the proxy's {code, error} envelope, report the
-// failure to the global surface, and bounce a 401 to the login page.
-// ---------------------------------------------------------------------------
-
-function fail(err) {
-  reportApiFailure(err)
-  return Promise.reject(err)
-}
-
-function retryAfterSeconds(headers) {
-  const raw = headers?.['retry-after'] ?? headers?.['Retry-After']
-  const n = Number(raw)
-  return Number.isFinite(n) ? n : null
-}
-
-client.interceptors.response.use(
-  (response) => {
-    // A 200 that is not JSON on an API path means the request fell through to
-    // a static/SPA fallback — i.e. the endpoint does not exist. Left alone,
-    // axios resolves and the caller reports success for a call that never
-    // happened, which is the phantom-endpoint lie. Reject it instead.
-    const url = response.config?.url || ''
-    const contentType = String(response.headers?.['content-type'] || '')
-    if (isJsonApiPath(url) && contentType && !contentType.includes('json')) {
-      return fail(new ApiError('Endpoint does not exist on this broker', {
-        status: response.status,
-        code: 'not_an_api_response',
-        path: url,
-      }))
-    }
-    reportApiSuccess()
-    return response
-  },
-  (error) => {
-    // An aborted request is a caller decision (unmount, tenant switch), not a
-    // failure: it must not paint a banner.
-    if (axios.isCancel?.(error) || error?.code === 'ERR_CANCELED') {
-      return Promise.reject(error)
-    }
-
-    const res = error.response
-    const status = res?.status ?? 0
-    const body = res?.data
-    const envelope = body && typeof body === 'object' ? body : null
-    const path = error.config?.url || null
-    const apiErr = new ApiError(
-      envelope?.error || envelope?.code || error.message || 'Network error',
-      {
-        status,
-        code: envelope?.code || null,
-        retryAfter: retryAfterSeconds(res?.headers),
-        body,
-        path,
-      }
-    )
-
-    // Contract: API paths never redirect, they 401. Reacting to that is the
-    // SPA's job, and this is the single place it happens.
-    if (status === 401) {
-      redirectToLogin()
-      // Navigating away: never settle, so no view flashes an error state on
-      // its way off screen.
-      return new Promise(() => {})
-    }
-
-    return fail(apiErr)
-  }
-)
 
 export { ApiError, CODE_ROUTE_BLOCKED }
 export default client

--- a/app/src/api/httpClient.js
+++ b/app/src/api/httpClient.js
@@ -1,0 +1,185 @@
+import ky, { isHTTPError } from 'ky'
+
+import { ApiError } from './errors.js'
+
+// Paths that answer JSON, never HTML. `/metrics/prometheus` is deliberately
+// out: it is the one gateway surface whose success body is text.
+const isJsonApiPath = (url = '') => url.startsWith('/api/') || url === '/health'
+
+/** Paths whose cluster attribution is set by the act-as header. */
+// `/api/console/*` is here for the SHARED-HOST console (one URL fronting many
+// clusters), where the Host names no cluster and the header is the only thing
+// that can — proxy/src/acting.rs `resolve_route_console`. Everywhere else the
+// console deliberately IGNORES the header (it is read only on a host listed in
+// QUEEN_PROXY_SHARED_HOSTS), so sending it changes nothing on a per-cluster
+// hostname or broker-direct.
+const isClusterScoped = (url = '') =>
+  url.startsWith('/api/v1/') || url.startsWith('/api/console/') ||
+  url.startsWith('/api/operator/') || url === '/health'
+
+function retryAfterSeconds(headers) {
+  const raw = headers?.get?.('retry-after')
+  if (raw === null || raw === undefined || raw === '') return null
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : null
+}
+
+function resolveUrl(path, apiBaseUrl) {
+  if (!apiBaseUrl) return path
+  return `${apiBaseUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
+}
+
+async function responseData(response, responseType) {
+  const body = await response.text()
+  if (responseType === 'text' || body === '') return body
+
+  // Keep a non-JSON success body as text. API routes are rejected earlier when
+  // their declared content type proves that the request fell through to the SPA.
+  try {
+    return JSON.parse(body)
+  } catch {
+    return body
+  }
+}
+
+function errorData(error) {
+  if (!isHTTPError(error) || typeof error.data !== 'string') {
+    return isHTTPError(error) ? error.data : null
+  }
+  try {
+    return JSON.parse(error.data)
+  } catch {
+    return error.data
+  }
+}
+
+/**
+ * Build the browser client around injectable side effects. The injection keeps
+ * the transport contract testable without a running broker or a browser.
+ */
+export function createApiClient({
+  apiBaseUrl = '',
+  getActingClusterHeader = () => null,
+  redirectToLogin = () => {},
+  reportApiFailure = () => {},
+  reportApiSuccess = () => {},
+  fetch: fetchImplementation,
+} = {}) {
+  // Keep the request semantics from the previous transport. In particular,
+  // Ky retries GET, PUT, and DELETE by default; console actions must happen
+  // once unless a caller explicitly starts a new request.
+  const transport = ky.create({
+    timeout: 30000,
+    retry: 0,
+    // The httpOnly `queen_session` cookie authenticates /api/v1/* and
+    // /api/console/* directly. `include` also covers broker-direct debugging
+    // when VITE_API_BASE_URL points at a different origin.
+    credentials: 'include',
+    ...(fetchImplementation ? { fetch: fetchImplementation } : {}),
+    hooks: {
+      beforeRequest: [
+        ({ request }) => {
+          const path = new URL(request.url).pathname
+          if (!isClusterScoped(path)) return
+          const act = getActingClusterHeader()
+          if (act) request.headers.set(act.name, act.value)
+        },
+      ],
+    },
+  })
+
+  function fail(err) {
+    reportApiFailure(err)
+    return Promise.reject(err)
+  }
+
+  /**
+   * Preserve the existing `{data, status, headers, config}` response shape, so
+   * swapping transports cannot silently change every view and store at once.
+   */
+  async function request(method, path, config = {}, json) {
+    const {
+      params,
+      responseType,
+      data: configBody,
+      ...requestOptions
+    } = config || {}
+
+    const options = {
+      ...requestOptions,
+      method,
+      retry: 0,
+      credentials: 'include',
+    }
+    if (params !== undefined) options.searchParams = params
+
+    const body = json === undefined ? configBody : json
+    if (body !== undefined) options.json = body
+
+    try {
+      const response = await transport(resolveUrl(path, apiBaseUrl), options)
+      const contentType = String(response.headers.get('content-type') || '')
+
+      // A 200 that is not JSON on an API path means the request fell through
+      // to a static/SPA fallback — i.e. the endpoint does not exist.
+      if (isJsonApiPath(path) && contentType && !contentType.includes('json')) {
+        return fail(new ApiError('Endpoint does not exist on this broker', {
+          status: response.status,
+          code: 'not_an_api_response',
+          path,
+        }))
+      }
+
+      const data = await responseData(response, responseType)
+      reportApiSuccess()
+      return {
+        data,
+        status: response.status,
+        headers: response.headers,
+        config: { url: path },
+      }
+    } catch (error) {
+      // An aborted request is a caller decision (unmount, tenant switch), not
+      // a failure: it must not paint a banner.
+      if (config?.signal?.aborted || error?.name === 'AbortError') throw error
+
+      // Response validation already produced the public error contract; only
+      // report it once.
+      if (error instanceof ApiError) return fail(error)
+
+      const response = isHTTPError(error) ? error.response : null
+      const status = response?.status ?? 0
+      const body = errorData(error)
+      const envelope = body && typeof body === 'object' ? body : null
+      const apiErr = new ApiError(
+        envelope?.error || envelope?.code || error?.message || 'Network error',
+        {
+          status,
+          code: envelope?.code || null,
+          retryAfter: retryAfterSeconds(response?.headers),
+          body,
+          path,
+        }
+      )
+
+      // Contract: API paths never redirect, they 401. Reacting to that is the
+      // SPA's job, and this is the single place it happens.
+      if (status === 401) {
+        redirectToLogin()
+        // Navigating away: never settle, so no view flashes an error state on
+        // its way off screen.
+        return new Promise(() => {})
+      }
+
+      return fail(apiErr)
+    }
+  }
+
+  return {
+    get: (path, config) => request('get', path, config),
+    delete: (path, config) => request('delete', path, config),
+    post: (path, data, config) => request('post', path, config, data),
+    put: (path, data, config) => request('put', path, config, data),
+    patch: (path, data, config) => request('patch', path, config, data),
+  }
+}

--- a/app/src/api/index.js
+++ b/app/src/api/index.js
@@ -146,7 +146,7 @@ export const consumers = {
     client.post(`/api/v1/consumer-groups/${encodeURIComponent(name)}/queues/${encodeURIComponent(queue)}/seek`, options, config),
   // `{toEnd:true}` EXPLICIT, never a null body. The broker's per-partition handler
   // defaults an *empty* body to toEnd, but this client sets a default
-  // `Content-Type: application/json`, so axios' transformRequest stringifies a null
+  // `Content-Type: application/json`, so a JSON client stringifies a null
   // payload into the 4 literal bytes `null` — non-empty, and not a struct, so
   // parse_seek answers 400 {"error":"bad body"} and the button never worked.
   seekPartition: (name, queue, partition, config) =>

--- a/app/src/components/Header.vue
+++ b/app/src/components/Header.vue
@@ -210,8 +210,8 @@ const loadMaintenanceStatus = async () => {
     failedMB.value = r.data.bufferStats?.failedFiles?.totalMB ?? 0
     maintenanceKnown.value = true
   } catch {
-    // The interceptor already surfaced the failure; here we only make sure the
-    // banners stop asserting a state we no longer know.
+    // The shared HTTP client already surfaced the failure; here we only make
+    // sure the banners stop asserting a state we no longer know.
     maintenanceKnown.value = false
   }
 }

--- a/app/src/composables/useApi.js
+++ b/app/src/composables/useApi.js
@@ -13,7 +13,7 @@ import { currentEpoch, onClusterChange } from '@/stores/identity'
  * an unreachable panel never renders as an empty or zeroed one.
  *
  * `fetchFn` receives `{ signal }` as its last argument — pass it through to
- * the api wrapper (every wrapper takes an axios config) and the request is
+ * the API wrapper (every wrapper accepts a request config) and the request is
  * aborted on unmount and on a cluster switch, so a late response can never
  * overwrite the new tenant's state.
  */

--- a/app/src/composables/useToast.js
+++ b/app/src/composables/useToast.js
@@ -1,6 +1,6 @@
 // View-facing handle on the global notification surface.
 //
-// API failures are ALREADY reported by the axios interceptor — do not
+// API failures are ALREADY reported by the shared HTTP client — do not
 // re-announce one you caught, or the same failure shows up twice. Use this for
 // what the shell cannot see: the outcome of a local action, a refusal you
 // decided yourself, a validation message.

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -12,7 +12,7 @@ import { notifyError } from './stores/ui'
 
 const app = createApp(App)
 
-// Backstop for everything the interceptors and the views do not catch. A
+// Backstop for everything the HTTP client and the views do not catch. A
 // render error or a stray rejection must not leave the product looking like
 // nothing happened.
 app.config.errorHandler = (err, _instance, info) => {

--- a/app/src/stores/ui.js
+++ b/app/src/stores/ui.js
@@ -1,7 +1,7 @@
 // Global error/notification surface — module singleton.
 //
 // The rule this store exists to enforce: NO failed call is invisible. The
-// axios interceptor reports every API failure here (see api/client.js), so a
+// shared HTTP client reports every API failure here (see api/client.js), so a
 // view that swallows an error still cannot make the product look healthy. A
 // dead broker paints a banner, not a dashboard of zeros.
 //

--- a/app/src/views/Consumers.vue
+++ b/app/src/views/Consumers.vue
@@ -512,7 +512,7 @@ import { useQueuesStore } from '@/stores/queuesStore'
 // mutating routes (delete / seek) are RouteClass::QueueAdmin at the proxy, so
 // their controls are shown only to a role that may actually use them.
 const { can, actingTenantSlug, actingClusterSlug, actingCellSlug } = useIdentity()
-// notifyWarn carries an outcome the interceptor cannot see: a 2xx that did
+// notifyWarn carries an outcome the shared HTTP client cannot see: a 2xx that did
 // nothing (no partition matched, nothing deleted) is a failure to the user.
 const { notifySuccess, notifyWarn } = useToast()
 const canAdmin = computed(() => can('queueAdmin'))
@@ -789,7 +789,7 @@ const moveToNow = async (g, label) => {
     )
     fetchConsumers()
   } catch {
-    // Already announced by the interceptor with the status and reason.
+    // Already announced by the shared HTTP client with the status and reason.
   }
 }
 
@@ -815,7 +815,7 @@ const skipPartition = async (p) => {
     notifySuccess(`Skipped ${p.partition_name} to the end`, `${p.queue_name} · ${p.consumer_group}`)
     await loadLaggingPartitions()
   } catch {
-    // Already announced by the interceptor.
+    // Already announced by the shared HTTP client.
   } finally {
     skippingPartition.value = null
   }

--- a/app/src/views/DeadLetter.vue
+++ b/app/src/views/DeadLetter.vue
@@ -717,7 +717,7 @@ const copyMarkdown = async () => {
 }
 
 // A failed load keeps whatever loaded last; the banner above says it is stale.
-// The failure itself is already on the global surface (axios interceptor).
+// The failure itself is already on the global surface (shared HTTP client).
 const fetchMessages = () => {
   const params = { limit: pageSize.value, offset: (page.value - 1) * pageSize.value }
   if (filterQueue.value) params.queue = filterQueue.value

--- a/app/src/views/Traces.vue
+++ b/app/src/views/Traces.vue
@@ -525,7 +525,7 @@ async function loadExampleTraceNames() {
       .slice(0, 8)
   } catch {
     // No suggestions rather than made-up ones; the failure is already reported
-    // by the interceptor and the search box still works.
+    // by the shared HTTP client and the search box still works.
     exampleTraceNames.value = []
   }
 }

--- a/app/test/httpClient.test.js
+++ b/app/test/httpClient.test.js
@@ -1,0 +1,190 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { ApiError } from '../src/api/errors.js'
+import { createApiClient } from '../src/api/httpClient.js'
+
+const jsonResponse = (body, init = {}) => new Response(JSON.stringify(body), {
+  ...init,
+  headers: {
+    'content-type': 'application/json',
+    ...init.headers,
+  },
+})
+
+test('HTTP client scopes requests, serializes params, and preserves the response facade', async () => {
+  let sent
+  let successes = 0
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test/',
+    getActingClusterHeader: () => ({ name: 'x-queen-act-cluster', value: 'cluster-a' }),
+    reportApiSuccess: () => { successes += 1 },
+    fetch: async request => {
+      sent = request
+      return jsonResponse({ queues: ['one'] })
+    },
+  })
+
+  const response = await client.get('/api/v1/resources/queues', {
+    params: { limit: 50, offset: 0 },
+  })
+
+  assert.equal(sent.url, 'https://queen.test/api/v1/resources/queues?limit=50&offset=0')
+  assert.equal(sent.headers.get('x-queen-act-cluster'), 'cluster-a')
+  assert.equal(sent.credentials, 'include')
+  assert.deepEqual(response.data, { queues: ['one'] })
+  assert.equal(response.status, 200)
+  assert.equal(response.config.url, '/api/v1/resources/queues')
+  assert.equal(successes, 1)
+})
+
+test('HTTP client sends mutation bodies as JSON', async () => {
+  let sentBody
+  let sentContentType
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test',
+    fetch: async request => {
+      sentBody = await request.clone().json()
+      sentContentType = request.headers.get('content-type')
+      return jsonResponse({ success: true }, { status: 201 })
+    },
+  })
+
+  const response = await client.post('/api/v1/push', { queue: 'jobs', value: 1 })
+
+  assert.deepEqual(sentBody, { queue: 'jobs', value: 1 })
+  assert.match(sentContentType, /^application\/json/)
+  assert.equal(response.status, 201)
+  assert.deepEqual(response.data, { success: true })
+})
+
+test('HTTP client does not retry a failed mutation and preserves the API error envelope', async () => {
+  let attempts = 0
+  let reported
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test',
+    reportApiFailure: error => { reported = error },
+    fetch: async () => {
+      attempts += 1
+      return jsonResponse(
+        { code: 'overloaded', error: 'Try later' },
+        { status: 503, headers: { 'retry-after': '7' } },
+      )
+    },
+  })
+
+  await assert.rejects(
+    client.delete('/api/v1/dlq'),
+    error => {
+      assert.ok(error instanceof ApiError)
+      assert.equal(error.message, 'Try later')
+      assert.equal(error.status, 503)
+      assert.equal(error.code, 'overloaded')
+      assert.equal(error.retryAfter, 7)
+      assert.equal(error.path, '/api/v1/dlq')
+      return true
+    },
+  )
+
+  assert.equal(attempts, 1)
+  assert.equal(reported?.status, 503)
+})
+
+test('HTTP client rejects an API route that falls through to HTML', async () => {
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test',
+    fetch: async () => new Response('<!doctype html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }),
+  })
+
+  await assert.rejects(
+    client.get('/api/v1/not-a-route'),
+    error => error instanceof ApiError &&
+      error.code === 'not_an_api_response' &&
+      error.status === 200,
+  )
+})
+
+test('HTTP client leaves caller aborts silent', async () => {
+  let failures = 0
+  const controller = new AbortController()
+  controller.abort()
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test',
+    reportApiFailure: () => { failures += 1 },
+    fetch: async request => {
+      if (request.signal.aborted) {
+        throw new DOMException('The operation was aborted', 'AbortError')
+      }
+      throw new Error('expected an aborted request')
+    },
+  })
+
+  await assert.rejects(
+    client.get('/api/v1/messages', { signal: controller.signal }),
+    error => error.name === 'AbortError',
+  )
+  assert.equal(failures, 0)
+})
+
+test('HTTP client returns the Prometheus surface as text', async () => {
+  let sent
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test',
+    getActingClusterHeader: () => ({ name: 'x-queen-act-cluster', value: 'cluster-a' }),
+    fetch: async request => {
+      sent = request
+      return new Response('queen_up 1\n', {
+        headers: { 'content-type': 'text/plain' },
+      })
+    },
+  })
+
+  const response = await client.get('/metrics/prometheus', { responseType: 'text' })
+  assert.equal(response.data, 'queen_up 1\n')
+  assert.equal(sent.headers.has('x-queen-act-cluster'), false)
+})
+
+test('HTTP client converts network failures into offline API errors', async () => {
+  let reported
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test',
+    reportApiFailure: error => { reported = error },
+    fetch: async () => { throw new TypeError('fetch failed') },
+  })
+
+  await assert.rejects(
+    client.get('/api/v1/resources/overview'),
+    error => error instanceof ApiError &&
+      error.status === 0 &&
+      error.isOffline &&
+      error.path === '/api/v1/resources/overview',
+  )
+  assert.equal(reported?.isOffline, true)
+})
+
+test('HTTP client redirects once on 401 without settling the caller', async () => {
+  let redirects = 0
+  let failures = 0
+  const client = createApiClient({
+    apiBaseUrl: 'https://queen.test',
+    redirectToLogin: () => { redirects += 1 },
+    reportApiFailure: () => { failures += 1 },
+    fetch: async () => jsonResponse(
+      { code: 'unauthorized', error: 'Sign in' },
+      { status: 401 },
+    ),
+  })
+
+  const request = client.get('/api/v1/resources/overview')
+  const outcome = await Promise.race([
+    request.then(() => 'settled', () => 'settled'),
+    new Promise(resolve => setTimeout(() => resolve('pending'), 10)),
+  ])
+
+  assert.equal(outcome, 'pending')
+  assert.equal(redirects, 1)
+  assert.equal(failures, 0)
+})


### PR DESCRIPTION
## Summary

- replace Axios with the Fetch-based Ky client
- preserve the dashboard's existing response facade and centralized ApiError contract
- keep the 30s timeout, cross-origin session credentials, acting-cluster header, silent aborts, 401 redirect, and SPA-fallback detection
- explicitly disable Ky retries so reads and mutations retain the existing one-request semantics
- add focused transport tests for query params, JSON bodies, error envelopes, retry behavior, aborts, offline failures, 401s, and text responses
- update documentation and remove Axios plus its transitive dependencies

## Verification

- npm test (31 passed)
- npm run build
- npm audit (0 vulnerabilities)
- npm outdated (no outdated packages)
- browser smoke test on the local Dashboard and DLQ screens

## Dependency

Stacked on #46; the base can be changed to master after #46 merges.