### PR TITLE
refactor(ui): align message detail drawers

### DIFF
--- a/app/src/components/DetailDrawer.vue
+++ b/app/src/components/DetailDrawer.vue
@@ -1,0 +1,98 @@
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="modal-backdrop" @click="emit('close')"></div>
+
+    <aside
+      v-if="open"
+      class="drawer-panel"
+      :class="{ 'detail-drawer-wide': wide }"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="title"
+    >
+      <div class="card-header detail-drawer-header">
+        <slot name="leading"></slot>
+        <h3>{{ title }}</h3>
+        <span v-if="subtitle" class="card-sub font-mono" :title="subtitle">{{ subtitle }}</span>
+        <div v-if="$slots.actions" class="detail-drawer-actions">
+          <slot name="actions"></slot>
+        </div>
+        <button
+          class="btn btn-ghost btn-icon modal-close"
+          :aria-label="`Close ${title}`"
+          @click="emit('close')"
+        >
+          <svg style="width:18px; height:18px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="card-body" :class="{ 'detail-drawer-split': split }">
+        <template v-if="split">
+          <div class="detail-drawer-primary"><slot></slot></div>
+          <div class="detail-drawer-secondary"><slot name="secondary"></slot></div>
+        </template>
+        <slot v-else></slot>
+      </div>
+
+      <div v-if="$slots.footer" class="modal-foot">
+        <slot name="footer"></slot>
+      </div>
+    </aside>
+  </Teleport>
+</template>
+
+<script setup>
+defineProps({
+  open: { type: Boolean, required: true },
+  title: { type: String, required: true },
+  subtitle: { type: String, default: '' },
+  wide: { type: Boolean, default: false },
+  split: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['close'])
+</script>
+
+<style scoped>
+.detail-drawer-header h3 { flex-shrink: 0; }
+
+.detail-drawer-header .card-sub {
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+.detail-drawer-actions {
+  display: flex; align-items: center; gap: 8px; flex-shrink: 0;
+}
+
+.detail-drawer-header .modal-close {
+  margin-left: 0; flex-shrink: 0;
+}
+
+.detail-drawer-wide { max-width: min(1120px, calc(100vw - 40px)); }
+.detail-drawer-split {
+  display: grid; grid-template-columns: minmax(300px, .8fr) minmax(420px, 1.2fr);
+  gap: 24px; align-items: start;
+}
+.detail-drawer-primary,
+.detail-drawer-secondary { min-width: 0; }
+.detail-drawer-secondary { padding-left: 24px; border-left: 1px solid var(--bd); }
+.detail-drawer-secondary :deep(.json-viewer) { max-height: calc(100vh - 112px); }
+
+@media (max-width: 640px) {
+  .detail-drawer-header .card-sub { display: none; }
+  .detail-drawer-actions { margin-left: auto; }
+}
+
+@media (max-width: 900px) {
+  .detail-drawer-wide { max-width: 640px; }
+  .detail-drawer-split { display: block; }
+  .detail-drawer-secondary {
+    margin-top: 24px; padding-top: 24px; padding-left: 0;
+    border-top: 1px solid var(--bd); border-left: 0;
+  }
+  .detail-drawer-secondary :deep(.json-viewer) { max-height: 400px; }
+}
+</style>

--- a/app/src/components/DetailField.vue
+++ b/app/src/components/DetailField.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="detail-field">
+    <div v-if="boxed" class="detail-field-header">
+      <label class="label-xs">{{ label }}</label>
+      <button
+        v-if="copyable && canCopy"
+        class="btn btn-ghost detail-field-copy"
+        :aria-label="`Copy ${label}`"
+        @click="copy"
+      >
+        {{ copied ? 'Copied!' : 'Copy' }}
+      </button>
+    </div>
+    <label v-else class="label-xs">{{ label }}</label>
+    <div :class="copyable && !boxed ? 'detail-field-copyable' : 'detail-field-value-wrap'">
+      <span
+        class="detail-field-value"
+        :class="[`detail-field-${tone}`, { 'font-mono': mono, 'detail-field-boxed': boxed }]"
+        :title="title"
+      >{{ displayValue }}</span>
+      <button
+        v-if="copyable && !boxed && canCopy"
+        class="btn btn-ghost detail-field-copy"
+        :aria-label="`Copy ${label}`"
+        @click="copy"
+      >
+        {{ copied ? 'Copied!' : 'Copy' }}
+      </button>
+    </div>
+    <slot></slot>
+  </div>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, ref } from 'vue'
+import { useToast } from '@/composables/useToast'
+
+const props = defineProps({
+  label: { type: String, required: true },
+  value: { type: [String, Number], default: '' },
+  mono: { type: Boolean, default: false },
+  copyable: { type: Boolean, default: false },
+  boxed: { type: Boolean, default: false },
+  tone: {
+    type: String,
+    default: 'mid',
+    validator: value => ['high', 'mid', 'accent', 'danger'].includes(value),
+  },
+  title: { type: String, default: '' },
+})
+
+const { notifyError } = useToast()
+const copied = ref(false)
+let resetTimer = null
+
+const displayValue = computed(() => props.value ?? '')
+const canCopy = computed(() => props.value !== null && props.value !== undefined && props.value !== '')
+
+const copy = async () => {
+  try {
+    await navigator.clipboard.writeText(String(props.value))
+    copied.value = true
+    clearTimeout(resetTimer)
+    resetTimer = setTimeout(() => { copied.value = false }, 2000)
+  } catch {
+    notifyError('Could not copy to the clipboard', 'Copy failed')
+  }
+}
+
+onBeforeUnmount(() => clearTimeout(resetTimer))
+</script>
+
+<style scoped>
+.detail-field { display: flex; flex-direction: column; gap: 4px; }
+.detail-field-value-wrap { min-width: 0; }
+.detail-field-value {
+  display: block; min-width: 0;
+  font-size: 13px; word-break: break-word;
+}
+.detail-field-value.font-mono { font-size: 12px; word-break: break-all; }
+.detail-field-high { color: var(--text-hi); font-weight: 500; }
+.detail-field-mid { color: var(--text-mid); }
+.detail-field-accent { color: var(--ice-400); }
+.detail-field-danger { color: var(--ember-400); }
+
+.detail-field-copyable { display: flex; align-items: flex-start; gap: 8px; }
+.detail-field-copyable .detail-field-value { flex: 1; }
+.detail-field-copy {
+  flex-shrink: 0; padding: 1px 6px; font-size: 10.5px;
+}
+.detail-field-header {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  margin-bottom: 4px;
+}
+.detail-field-boxed {
+  max-height: 180px; overflow: auto;
+  padding: 14px 16px; border: 1px solid var(--bd); border-radius: var(--r-card);
+  background: var(--recessed); line-height: 1.6; white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/app/src/components/JsonViewer.vue
+++ b/app/src/components/JsonViewer.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="json-viewer">
+    <VueJsonPretty
+      :data="normalizedValue"
+      :deep="4"
+      :collapsed-node-length="20"
+      :show-length="true"
+      :show-line="true"
+      :show-icon="true"
+      theme="dark"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import VueJsonPretty from 'vue-json-pretty'
+import 'vue-json-pretty/lib/styles.css'
+
+const props = defineProps({
+  value: { type: null, required: true },
+})
+
+// Message detail historically returned both decoded JSON values and JSON text.
+// Parse only valid JSON strings so plain-text payloads remain visibly strings.
+const normalizedValue = computed(() => {
+  if (typeof props.value !== 'string') return props.value
+  try {
+    return JSON.parse(props.value)
+  } catch {
+    return props.value
+  }
+})
+</script>
+
+<style scoped>
+.json-viewer {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px; line-height: 1.6;
+  padding: 14px 16px; border-radius: var(--r-card);
+  border: 1px solid var(--bd);
+  color: var(--text-mid); background: var(--recessed);
+  overflow: auto; max-height: 400px;
+}
+
+.json-viewer :deep(.vjs-tree) { font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+.json-viewer :deep(.vjs-key) { color: var(--ice-400); }
+.json-viewer :deep(.vjs-value-string) { color: var(--ok-500); }
+.json-viewer :deep(.vjs-value-number),
+.json-viewer :deep(.vjs-value-boolean) { color: var(--crown-400); }
+.json-viewer :deep(.vjs-value-null),
+.json-viewer :deep(.vjs-value-undefined) { color: var(--ember-400); }
+.json-viewer :deep(.vjs-comment),
+.json-viewer :deep(.vjs-tree-brackets) { color: var(--text-low); }
+.json-viewer :deep(.vjs-tree-node.dark:hover) { background: var(--ink-4); }
+.json-viewer :deep(.vjs-indent-unit.has-line) { border-left-color: var(--bd-hi); }
+</style>

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -969,6 +969,39 @@
     border-left: 1px solid var(--bd);
   }
 
+  /* --- Drawer detail language -------------------------------------------
+     Message and DLQ detail use one vertical rhythm. Their data and actions
+     differ, but routing, payload and status should not move between views. */
+  .detail-status-row {
+    display: flex; align-items: center; gap: 6px; margin-bottom: 20px;
+  }
+  .detail-fields { display: flex; flex-direction: column; gap: 16px; }
+  .detail-section { margin-top: 24px; }
+  .detail-section-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 8px;
+  }
+  .detail-section-title {
+    margin-bottom: 8px; font-size: 10.5px; letter-spacing: .14em;
+    text-transform: uppercase; font-weight: 500; color: var(--text-low);
+  }
+  .detail-copy-button { padding: 2px 8px; font-size: 11px; }
+  .detail-note { font-size: 11px; color: var(--text-low); }
+  .detail-actions {
+    display: flex; flex-direction: column; gap: 8px;
+    margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--bd);
+  }
+  .detail-config-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
+    padding: 14px 16px; font-size: 13px;
+  }
+  .detail-config-grid > div { display: flex; align-items: baseline; gap: 4px; }
+  .detail-config-grid span { color: var(--text-low); }
+  .detail-config-grid strong {
+    color: var(--text-hi); font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums; font-weight: 500;
+  }
+
   /* --- Multi-select pill row ---------------------------------------------
      A `.pill` row is multi-select; a `.seg` is single-select. Keeping them
      visually distinct is load-bearing. */

--- a/app/src/views/DeadLetter.vue
+++ b/app/src/views/DeadLetter.vue
@@ -299,152 +299,119 @@
           </div>
         </div>
       </div>
-
-      <div v-if="selectedMsg" class="modal-backdrop" @click="closeDetail"></div>
-
-      <div v-if="selectedMsg" class="drawer-panel dlq-detail-drawer">
-        <div class="card-header dlq-detail-header">
-          <h3>DLQ Message Detail</h3>
-          <span class="card-sub font-mono">{{ selectedMsg.transactionId || selectedMsg.id }}</span>
-          <button
-            class="btn btn-ghost dlq-copy-report"
-            title="Copy the failure, routing details, timestamps, and payload as Markdown"
-            @click="copyMarkdown"
-          >
-            {{ markdownCopied ? 'Markdown copied!' : 'Copy as Markdown' }}
-          </button>
-          <button @click="closeDetail" class="btn btn-ghost btn-icon modal-close" aria-label="Close message detail">
-            <svg style="width:18px; height:18px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
-          </button>
-        </div>
-
-        <div class="card-body dlq-detail-body">
-          <div class="dlq-detail-summary">
-            <!-- Status chips -->
-            <div class="dlq-detail-status">
-              <span class="chip chip-bad">dead_letter</span>
-              <span v-if="selectedMsg.retryCount" class="chip chip-warn">
-                {{ selectedMsg.retryCount }} retries
-              </span>
-            </div>
-
-            <!-- Key-value fields -->
-            <div class="dlq-kv">
-              <div class="dlq-kv-row">
-                <label class="label-xs">Queue</label>
-                <span style="font-weight:500; color:var(--text-hi);">{{ selectedMsg.queue }}</span>
-              </div>
-              <div class="dlq-kv-row">
-                <label class="label-xs">Partition</label>
-                <div class="dlq-copyable-field">
-                  <span class="font-mono">{{ selectedMsg.partition }}</span>
-                  <button class="btn btn-ghost" aria-label="Copy partition" @click="copyField('partition', selectedMsg.partition)">
-                    {{ copiedField === 'partition' ? 'Copied!' : 'Copy' }}
-                  </button>
-                </div>
-              </div>
-              <div class="dlq-kv-row">
-                <label class="label-xs">Partition ID</label>
-                <div class="dlq-copyable-field">
-                  <span class="font-mono">{{ selectedMsg.partitionId }}</span>
-                  <button class="btn btn-ghost" aria-label="Copy partition ID" @click="copyField('partitionId', selectedMsg.partitionId)">
-                    {{ copiedField === 'partitionId' ? 'Copied!' : 'Copy' }}
-                  </button>
-                </div>
-              </div>
-              <div class="dlq-kv-row">
-                <label class="label-xs">Transaction ID</label>
-                <div class="dlq-copyable-field">
-                  <span class="font-mono">{{ selectedMsg.transactionId }}</span>
-                  <button class="btn btn-ghost" aria-label="Copy transaction ID" @click="copyField('transactionId', selectedMsg.transactionId)">
-                    {{ copiedField === 'transactionId' ? 'Copied!' : 'Copy' }}
-                  </button>
-                </div>
-              </div>
-              <div class="dlq-kv-row">
-                <label class="label-xs">Consumer group</label>
-                <span class="font-mono" style="font-size:12px; color:var(--ice-400);">{{ selectedMsg.consumerGroup }}</span>
-              </div>
-              <!-- The log engine cannot recover the enqueue time from an opaque
-                   blob, so it echoes failed_at as createdAt. Showing the same
-                   instant twice under two labels invents a fact. -->
-              <div v-if="hasDistinctCreatedAt(selectedMsg)" class="dlq-kv-row">
-                <label class="label-xs">Created</label>
-                <span :title="formatTimestampUtc(selectedMsg.createdAt)" style="font-size:13px; color:var(--text-mid);">{{ formatTimestamp(selectedMsg.createdAt) }}</span>
-              </div>
-              <div class="dlq-kv-row">
-                <label class="label-xs">Failed at</label>
-                <span :title="formatTimestampUtc(selectedMsg.failedAt)" style="font-size:13px; color:var(--text-mid);">{{ formatTimestamp(selectedMsg.failedAt) }}</span>
-                <span v-if="!hasDistinctCreatedAt(selectedMsg)" style="font-size:11px; color:var(--text-low);">
-                  Enqueue time is not recorded for this entry.
-                </span>
-              </div>
-            </div>
-
-            <div v-if="selectedMsg.errorMessage" class="dlq-error-panel">
-              <div class="dlq-block-header">
-                <label class="label-xs">Error</label>
-                <button class="btn btn-ghost" style="padding:2px 8px; font-size:11px;" @click="copyField('error', selectedMsg.errorMessage)">
-                  {{ copiedField === 'error' ? 'Copied!' : 'Copy' }}
-                </button>
-              </div>
-              <div class="dlq-code dlq-error-box">{{ selectedMsg.errorMessage }}</div>
-            </div>
-
-            <!-- Actions. No "replay": the broker exposes no re-push route for a
-                 DLQ snapshot, and a button that cannot verify its own outcome is
-                 worse than no button. -->
-            <div v-if="canAdmin" class="dlq-detail-actions">
-              <button class="btn btn-danger" style="width:100%; justify-content:center;" @click="purge(selectedMsg)" :disabled="isDeleting(selectedMsg)">
-                {{ isDeleting(selectedMsg) ? 'Purging…' : 'Purge message' }}
-              </button>
-              <p v-if="rowError(selectedMsg)" style="font-size:12px; color:var(--ember-400);">{{ rowError(selectedMsg) }}</p>
-            </div>
-            <p v-else class="dlq-detail-permission">
-              Purging needs the admin role on this cluster.
-            </p>
-          </div>
-
-          <!-- Payload gets the larger column: long JSON is the exceptional case
-               where the shared compact drawer would waste the viewport. -->
-          <div v-if="selectedMsg.data !== undefined" class="dlq-payload-panel">
-            <div class="dlq-block-header">
-              <label class="label-xs">Payload</label>
-              <button class="btn btn-ghost" style="padding:2px 8px; font-size:11px;" @click="copyPayload">
-                {{ copied ? 'Copied!' : (encryptedPayload ? 'Copy envelope' : 'Copy') }}
-              </button>
-            </div>
-            <!-- The DLQ read path does no decryption: what follows is the stored
-                 envelope, not the message. Saying "payload" over ciphertext is
-                 how a debugger loses an hour. -->
-            <div v-if="encryptedPayload" class="status-banner banner-warn view-banner">
-              <span>
-                <strong>Encrypted envelope</strong> · this queue encrypts payloads and the DLQ endpoint
-                returns them as stored. This is ciphertext, not the message body.
-              </span>
-            </div>
-            <div class="dlq-code dlq-json-viewer">
-              <VueJsonPretty
-                :data="selectedMsg.data"
-                :deep="4"
-                :collapsed-node-length="20"
-                :show-length="true"
-                :show-line="true"
-                :show-icon="true"
-                theme="dark"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
     </Teleport>
+
+    <DetailDrawer
+      :open="Boolean(selectedMsg)"
+      title="DLQ Message Detail"
+      :subtitle="selectedMsg?.transactionId || selectedMsg?.id || ''"
+      wide
+      split
+      @close="closeDetail"
+    >
+      <template #actions>
+        <button
+          class="btn btn-ghost"
+          title="Copy the failure, routing details, timestamps, and payload as Markdown"
+          @click="copyMarkdown"
+        >
+          {{ markdownCopied ? 'Markdown copied!' : 'Copy as Markdown' }}
+        </button>
+      </template>
+
+      <template v-if="selectedMsg">
+        <div class="detail-status-row">
+          <span class="chip chip-bad">dead_letter</span>
+          <span v-if="selectedMsg.retryCount" class="chip chip-warn">
+            {{ selectedMsg.retryCount }} retries
+          </span>
+        </div>
+
+        <div class="detail-fields">
+          <DetailField label="Queue" :value="selectedMsg.queue" tone="high" />
+          <DetailField label="Partition" :value="selectedMsg.partition" mono copyable />
+          <DetailField label="Partition ID" :value="selectedMsg.partitionId" mono copyable />
+          <DetailField label="Transaction ID" :value="selectedMsg.transactionId" mono copyable />
+          <DetailField label="Consumer group" :value="selectedMsg.consumerGroup" mono tone="accent" />
+
+          <!-- The log engine cannot recover the enqueue time from an opaque
+               blob, so it echoes failed_at as createdAt. Showing the same
+               instant twice under two labels invents a fact. -->
+          <DetailField
+            v-if="hasDistinctCreatedAt(selectedMsg)"
+            label="Created"
+            :value="formatTimestamp(selectedMsg.createdAt)"
+            :title="formatTimestampUtc(selectedMsg.createdAt)"
+          />
+          <DetailField
+            label="Failed at"
+            :value="formatTimestamp(selectedMsg.failedAt)"
+            :title="formatTimestampUtc(selectedMsg.failedAt)"
+          >
+            <span v-if="!hasDistinctCreatedAt(selectedMsg)" class="detail-note">
+              Enqueue time is not recorded for this entry.
+            </span>
+          </DetailField>
+        </div>
+
+        <DetailField
+          v-if="selectedMsg.errorMessage"
+          class="detail-section"
+          label="Error"
+          :value="selectedMsg.errorMessage"
+          mono
+          copyable
+          boxed
+          tone="danger"
+        />
+
+        <!-- Actions. No "replay": the broker exposes no re-push route for a
+             DLQ snapshot, and a button that cannot verify its own outcome is
+             worse than no button. -->
+        <div v-if="canAdmin" class="detail-actions">
+          <button
+            class="btn btn-danger"
+            style="width:100%; justify-content:center;"
+            :disabled="isDeleting(selectedMsg)"
+            @click="purge(selectedMsg)"
+          >
+            {{ isDeleting(selectedMsg) ? 'Purging…' : 'Purge message' }}
+          </button>
+          <p v-if="rowError(selectedMsg)" style="font-size:12px; color:var(--ember-400);">
+            {{ rowError(selectedMsg) }}
+          </p>
+        </div>
+        <p v-else class="detail-actions detail-note">
+          Purging needs the admin role on this cluster.
+        </p>
+      </template>
+
+      <template #secondary>
+        <div v-if="selectedMsg?.data !== undefined">
+          <div class="detail-section-header">
+            <label class="label-xs">Payload</label>
+            <button class="btn btn-ghost detail-copy-button" @click="copyPayload">
+              {{ copied ? 'Copied!' : (encryptedPayload ? 'Copy envelope' : 'Copy') }}
+            </button>
+          </div>
+          <!-- The DLQ read path does no decryption: what follows is the stored
+               envelope, not the message. Saying "payload" over ciphertext is
+               how a debugger loses an hour. -->
+          <div v-if="encryptedPayload" class="status-banner banner-warn view-banner">
+            <span>
+              <strong>Encrypted envelope</strong> · this queue encrypts payloads and the DLQ endpoint
+              returns them as stored. This is ciphertext, not the message body.
+            </span>
+          </div>
+          <JsonViewer :value="selectedMsg.data" />
+        </div>
+      </template>
+    </DetailDrawer>
   </div>
 </template>
 
 <script setup>
 import { ref, computed, watch } from 'vue'
-import VueJsonPretty from 'vue-json-pretty'
-import 'vue-json-pretty/lib/styles.css'
 import { dlq, queues as queuesApi, describeApiError } from '@/api'
 import { useApi, formatNumber, formatRelativeTime } from '@/composables/useApi'
 import { formatDlqMarkdown } from '@/composables/useDlqMarkdown'
@@ -454,6 +421,9 @@ import { stamp } from '@/composables/useStamp'
 import { useToast } from '@/composables/useToast'
 import { useIdentity } from '@/stores/identity'
 import Autocomplete from '@/components/Autocomplete.vue'
+import DetailDrawer from '@/components/DetailDrawer.vue'
+import DetailField from '@/components/DetailField.vue'
+import JsonViewer from '@/components/JsonViewer.vue'
 
 const { can, actingTenantSlug, actingClusterSlug, actingCellSlug } = useIdentity()
 const { notifySuccess, notifyError } = useToast()
@@ -472,7 +442,6 @@ const errorKey = (msg) => msg.errorMessage || NO_ERROR_TEXT
 const selectedKey = ref(null)
 const copied = ref(false)
 const markdownCopied = ref(false)
-const copiedField = ref(null)
 // Client-side narrowing of the loaded page by one error text. Not a request
 // parameter: the DLQ endpoint takes queue and consumerGroup only.
 const errorFilter = ref(null)
@@ -669,7 +638,6 @@ const selectMessage = (msg) => {
   selectedKey.value = selectedKey.value === msgKey(msg) ? null : msgKey(msg)
   copied.value = false
   markdownCopied.value = false
-  copiedField.value = null
 }
 
 const closeDetail = () => { selectedKey.value = null }
@@ -689,16 +657,6 @@ const copyPayload = async () => {
   if (await writeClipboard(JSON.stringify(selectedMsg.value.data, null, 2))) {
     copied.value = true
     setTimeout(() => { copied.value = false }, 2000)
-  }
-}
-
-const copyField = async (field, value) => {
-  if (value === null || value === undefined) return
-  if (await writeClipboard(String(value))) {
-    copiedField.value = field
-    setTimeout(() => {
-      if (copiedField.value === field) copiedField.value = null
-    }, 2000)
   }
 }
 
@@ -882,86 +840,4 @@ fetchMessages()
 .dlq-filter-chip { cursor: pointer; max-width: 340px; }
 .dlq-filter-chip-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-.dlq-kv { display: flex; flex-direction: column; gap: 16px; }
-.dlq-kv-row { display: flex; flex-direction: column; gap: 4px; }
-
-/* Message detail is the one drawer that benefits from desktop width: its two
-   independent reading surfaces can sit together instead of forming one long
-   scroll. Shared Messages and Traces drawers remain compact. */
-.dlq-detail-drawer { max-width: min(1120px, calc(100vw - 40px)); }
-.dlq-detail-body {
-  display: grid; grid-template-columns: minmax(300px, .8fr) minmax(420px, 1.2fr);
-  gap: 24px; align-items: start;
-}
-.dlq-detail-summary,
-.dlq-payload-panel { min-width: 0; }
-.dlq-detail-status { display: flex; align-items: center; gap: 6px; margin-bottom: 20px; }
-.dlq-payload-panel { padding-left: 24px; border-left: 1px solid var(--bd); }
-.dlq-block-header {
-  display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;
-}
-.dlq-error-panel { margin-top: 20px; }
-.dlq-detail-actions,
-.dlq-detail-permission {
-  margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--bd);
-}
-.dlq-detail-actions { display: flex; flex-direction: column; gap: 8px; }
-.dlq-detail-permission { font-size: 12px; color: var(--text-low); }
-
-.dlq-detail-header h3,
-.dlq-copy-report { flex-shrink: 0; }
-.dlq-detail-header .card-sub {
-  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.dlq-detail-header .modal-close { margin-left: 0; flex-shrink: 0; }
-
-.dlq-copyable-field { display: flex; align-items: flex-start; gap: 8px; }
-.dlq-copyable-field .font-mono {
-  flex: 1; min-width: 0; font-size: 12px; color: var(--text-mid); word-break: break-all;
-}
-.dlq-copyable-field .btn { flex-shrink: 0; padding: 1px 6px; font-size: 10.5px; }
-
-/* Stored envelope / payload: recessed against the drawer. */
-.dlq-code {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px; line-height: 1.6;
-  padding: 14px 16px; border-radius: var(--r-card);
-  border: 1px solid var(--bd);
-  color: var(--text-mid);
-  background: var(--recessed);
-  white-space: pre; overflow-x: auto;
-  max-height: calc(100vh - 112px); overflow-y: auto;
-}
-
-.dlq-json-viewer { white-space: normal; }
-.dlq-error-box {
-  max-height: 180px; color: var(--ember-400);
-  white-space: pre-wrap; overflow-wrap: anywhere;
-}
-.dlq-json-viewer :deep(.vjs-tree) { font-family: 'JetBrains Mono', monospace; font-size: 12px; }
-.dlq-json-viewer :deep(.vjs-key) { color: var(--ice-400); }
-.dlq-json-viewer :deep(.vjs-value-string) { color: var(--ok-500); }
-.dlq-json-viewer :deep(.vjs-value-number),
-.dlq-json-viewer :deep(.vjs-value-boolean) { color: var(--crown-400); }
-.dlq-json-viewer :deep(.vjs-value-null),
-.dlq-json-viewer :deep(.vjs-value-undefined) { color: var(--ember-400); }
-.dlq-json-viewer :deep(.vjs-comment),
-.dlq-json-viewer :deep(.vjs-tree-brackets) { color: var(--text-low); }
-.dlq-json-viewer :deep(.vjs-tree-node.dark:hover) { background: var(--ink-4); }
-.dlq-json-viewer :deep(.vjs-indent-unit.has-line) { border-left-color: var(--bd-hi); }
-
-@media (max-width: 640px) {
-  .dlq-detail-header .card-sub { display: none; }
-  .dlq-copy-report { margin-left: auto; }
-}
-
-@media (max-width: 900px) {
-  .dlq-detail-drawer { max-width: 640px; }
-  .dlq-detail-body { display: block; }
-  .dlq-payload-panel {
-    margin-top: 24px; padding-top: 24px; padding-left: 0;
-    border-top: 1px solid var(--bd); border-left: 0;
-  }
-  .dlq-code { max-height: 400px; }
-}
 </style>

--- a/app/src/views/Messages.vue
+++ b/app/src/views/Messages.vue
@@ -277,150 +277,81 @@
       </div>
     </div>
 
-    <!-- Message detail panel (teleported to body to avoid transform issues) -->
-    <Teleport to="body">
-      <!-- Backdrop before the panel, so DOM order matches paint order. -->
-      <div v-if="selectedMessage" class="modal-backdrop" @click="closePanel"></div>
+    <DetailDrawer
+      :open="Boolean(selectedMessage)"
+      title="Message Detail"
+      :subtitle="messageDetail?.transactionId || selectedMessage?.transactionId || ''"
+      wide
+      :split="Boolean(messageDetail)"
+      @close="closePanel"
+    >
+      <div v-if="detailLoading" style="text-align:center; padding:48px 0;">
+        <div class="spinner" style="margin:0 auto 12px;"></div>
+        <p style="color:var(--text-low);">Loading details...</p>
+      </div>
 
-      <div v-if="selectedMessage" class="drawer-panel">
-        <div class="card-header">
-          <h3>Message Details</h3>
-          <span v-if="messageDetail?.transactionId" class="card-sub font-mono">{{ messageDetail.transactionId }}</span>
-          <button
-            @click="closePanel"
-            class="btn btn-ghost btn-icon modal-close"
-          >
-            <svg style="width:18px; height:18px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      <div class="card-body">
-        <div v-if="detailLoading" style="text-align:center; padding:48px 0;">
-          <div class="spinner" style="margin:0 auto 12px;"></div>
-          <p style="color:var(--text-low);">Loading details...</p>
-        </div>
+      <div v-else-if="detailError" class="panel-err">
+        {{ detailError }}
+      </div>
 
-        <div v-else-if="detailError" class="panel-err">
-          {{ detailError }}
-        </div>
-
-        <template v-else-if="messageDetail">
-          <!-- Status -->
-          <div style="margin-bottom:24px;">
-            <div style="margin-bottom:20px;">
-              <span
-                class="chip"
-                style="font-size:12px;"
-                :class="{
-                  'chip-ice': messageDetail.status === 'pending',
-                  'chip-warn': messageDetail.status === 'processing',
-                  'chip-ok': messageDetail.status === 'completed',
-                  'chip-bad': messageDetail.status === 'dead_letter' || messageDetail.status === 'failed'
-                }"
-              >
-                {{ messageDetail.status }}
-              </span>
-            </div>
-
-            <div style="display:flex; flex-direction:column; gap:16px;">
-              <div>
-                <label class="label-xs" style="display:block; margin-bottom:6px;">Queue / Partition</label>
-                <p style="font-size:13px; font-weight:500; color:var(--text-hi);">
-                  {{ messageDetail.queue }} / {{ messageDetail.partition }}
-                </p>
-              </div>
-
-              <div>
-                <label class="label-xs" style="display:block; margin-bottom:6px;">Partition ID</label>
-                <p class="font-mono" style="font-size:11px; color:var(--text-mid); word-break:break-all;">{{ messageDetail.partitionId }}</p>
-              </div>
-
-              <div>
-                <label class="label-xs" style="display:block; margin-bottom:6px;">Transaction ID</label>
-                <p class="font-mono" style="font-size:11px; color:var(--text-mid); word-break:break-all;">{{ messageDetail.transactionId }}</p>
-              </div>
-
-              <div>
-                <label class="label-xs" style="display:block; margin-bottom:6px;">Created</label>
-                <p :title="formatTimestampUtc(messageDetail.createdAt)" style="font-size:13px; color:var(--text-mid);">{{ formatTimestamp(messageDetail.createdAt) }}</p>
-              </div>
-
-              <div v-if="messageDetail.traceId">
-                <label class="label-xs" style="display:block; margin-bottom:6px;">Trace ID</label>
-                <p class="font-mono" style="font-size:11px; color:var(--text-mid); word-break:break-all;">{{ messageDetail.traceId }}</p>
-              </div>
-
-              <div v-if="messageDetail.errorMessage">
-                <label class="label-xs" style="display:block; margin-bottom:6px;">Error Message</label>
-                <p style="font-size:13px; color:var(--ember-400);">{{ messageDetail.errorMessage }}</p>
-              </div>
-
-              <div v-if="messageDetail.retryCount">
-                <label class="label-xs" style="display:block; margin-bottom:6px;">Retry Count</label>
-                <p class="font-mono tabular-nums" style="font-size:13px; color:var(--text-mid);">{{ messageDetail.retryCount }}</p>
-              </div>
-            </div>
+      <template v-else-if="messageDetail">
+          <!-- Status and routing match the DLQ drawer: the same facts occupy
+               the same positions and identifiers are directly copyable. -->
+          <div class="detail-status-row">
+            <span
+              class="chip"
+              :class="{
+                'chip-ice': messageDetail.status === 'pending',
+                'chip-warn': messageDetail.status === 'processing',
+                'chip-ok': messageDetail.status === 'completed',
+                'chip-bad': messageDetail.status === 'dead_letter' || messageDetail.status === 'failed'
+              }"
+            >
+              {{ messageDetail.status }}
+            </span>
+            <span v-if="messageDetail.retryCount" class="chip chip-warn">
+              {{ messageDetail.retryCount }} retries
+            </span>
           </div>
+
+          <div class="detail-fields">
+            <DetailField label="Queue" :value="messageDetail.queue" tone="high" />
+            <DetailField label="Partition" :value="messageDetail.partition" mono copyable />
+            <DetailField label="Partition ID" :value="messageDetail.partitionId" mono copyable />
+            <DetailField label="Transaction ID" :value="messageDetail.transactionId" mono copyable />
+            <DetailField
+              label="Created"
+              :value="formatTimestamp(messageDetail.createdAt)"
+              :title="formatTimestampUtc(messageDetail.createdAt)"
+            />
+            <DetailField v-if="messageDetail.traceId" label="Trace ID" :value="messageDetail.traceId" mono copyable />
+          </div>
+
+          <DetailField
+            v-if="messageDetail.errorMessage"
+            class="detail-section"
+            label="Error"
+            :value="messageDetail.errorMessage"
+            mono
+            copyable
+            boxed
+            tone="danger"
+          />
 
           <!-- Queue Config -->
-          <div v-if="messageDetail.queueConfig" style="margin-bottom:24px;">
-            <h4 style="font-size:13px; font-weight:600; margin-bottom:12px; color:var(--text-hi);">Queue Config</h4>
-            <div class="card" style="padding:14px 16px;">
-              <div style="display:grid; grid-template-columns:1fr 1fr; gap:10px; font-size:13px;">
-                <div>
-                  <span style="color:var(--text-low);">Lease Time:</span>
-                  <span class="font-mono tabular-nums" style="font-weight:500; margin-left:4px; color:var(--text-hi);">{{ messageDetail.queueConfig.leaseTime }}s</span>
-                </div>
-                <div>
-                  <span style="color:var(--text-low);">TTL:</span>
-                  <span class="font-mono tabular-nums" style="font-weight:500; margin-left:4px; color:var(--text-hi);">{{ messageDetail.queueConfig.ttl }}s</span>
-                </div>
-                <div>
-                  <span style="color:var(--text-low);">Retry Limit:</span>
-                  <span class="font-mono tabular-nums" style="font-weight:500; margin-left:4px; color:var(--text-hi);">{{ messageDetail.queueConfig.retryLimit }}</span>
-                </div>
-                <div>
-                  <span style="color:var(--text-low);">Retry Delay:</span>
-                  <span class="font-mono tabular-nums" style="font-weight:500; margin-left:4px; color:var(--text-hi);">{{ messageDetail.queueConfig.retryDelay }}ms</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Payload -->
-          <div style="margin-bottom:24px;">
-            <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:12px;">
-              <h4 style="font-size:13px; font-weight:600; color:var(--text-hi);">Payload</h4>
-              <button
-                v-if="payloadAvailable"
-                @click="copyPayload"
-                class="btn btn-ghost" style="padding:4px 8px; font-size:11px; gap:4px;"
-              >
-                <svg v-if="!payloadCopied" style="width:14px; height:14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-                <svg v-else style="width:14px; height:14px; color:var(--ok-500);" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-                </svg>
-                {{ payloadCopied ? 'Copied!' : 'Copy' }}
-              </button>
-            </div>
-            <!-- payloadAvailable:false means the segment is gone. An empty
-                 payload box would read as "this message carried nothing". -->
-            <div v-if="!payloadAvailable" class="card" style="padding:12px 14px;">
-              <p style="font-size:13px; color:var(--text-mid);">
-                Payload unavailable — the covering log segment was removed by retention.
-              </p>
-            </div>
-            <div v-else class="msg-code">
-              <pre class="font-mono" style="font-size:12px; white-space:pre-wrap; margin:0;" v-html="highlightJson(messageDetail.payload)"></pre>
+          <div v-if="messageDetail.queueConfig" class="detail-section">
+            <h4 class="detail-section-title">Queue Config</h4>
+            <div class="card detail-config-grid">
+              <div><span>Lease time</span><strong>{{ messageDetail.queueConfig.leaseTime }}s</strong></div>
+              <div><span>TTL</span><strong>{{ messageDetail.queueConfig.ttl }}s</strong></div>
+              <div><span>Retry limit</span><strong>{{ messageDetail.queueConfig.retryLimit }}</strong></div>
+              <div><span>Retry delay</span><strong>{{ messageDetail.queueConfig.retryDelay }}ms</strong></div>
             </div>
           </div>
 
           <!-- Consumer Groups -->
-          <div v-if="messageDetail.consumerGroups && messageDetail.consumerGroups.length > 0" style="margin-bottom:24px;">
-            <h4 style="font-size:13px; font-weight:600; margin-bottom:12px; color:var(--text-hi);">Consumer Groups</h4>
+          <div v-if="messageDetail.consumerGroups && messageDetail.consumerGroups.length > 0" class="detail-section">
+            <h4 class="detail-section-title">Consumer Groups</h4>
             <div style="display:flex; flex-direction:column; gap:8px;">
               <div
                 v-for="group in messageDetail.consumerGroups"
@@ -440,7 +371,7 @@
           </div>
 
           <!-- Actions -->
-          <div style="display:flex; flex-direction:column; gap:8px; padding-top:8px;">
+          <div class="detail-actions">
             <!-- Sits with the button that produced it: this drawer scrolls, and
                  a delete failure hoisted to the top would land off screen. -->
             <div v-if="actionError" class="panel-err">{{ actionError }}</div>
@@ -479,10 +410,31 @@
               re-routed from here. Only dead-lettered entries can be purged.
             </p>
           </div>
-        </template>
-      </div>
-      </div>
-    </Teleport>
+      </template>
+
+      <template #secondary>
+        <div v-if="messageDetail">
+          <div class="detail-section-header">
+            <label class="label-xs">Payload</label>
+            <button
+              v-if="payloadAvailable"
+              class="btn btn-ghost detail-copy-button"
+              @click="copyPayload"
+            >
+              {{ payloadCopied ? 'Copied!' : 'Copy' }}
+            </button>
+          </div>
+          <!-- payloadAvailable:false means the segment is gone. An empty
+               payload box would read as "this message carried nothing". -->
+          <div v-if="!payloadAvailable" class="card" style="padding:12px 14px;">
+            <p style="font-size:13px; color:var(--text-mid);">
+              Payload unavailable — the covering log segment was removed by retention.
+            </p>
+          </div>
+          <JsonViewer v-else :value="messageDetail.payload" />
+        </div>
+      </template>
+    </DetailDrawer>
   </div>
 </template>
 
@@ -497,10 +449,13 @@ import { stamp } from '@/composables/useStamp'
 import { useToast } from '@/composables/useToast'
 import { useIdentity } from '@/stores/identity'
 import Autocomplete from '@/components/Autocomplete.vue'
+import DetailDrawer from '@/components/DetailDrawer.vue'
+import DetailField from '@/components/DetailField.vue'
+import JsonViewer from '@/components/JsonViewer.vue'
 
 const route = useRoute()
 const { can, actingTenantSlug, actingClusterSlug, actingCellSlug } = useIdentity()
-const { notifySuccess } = useToast()
+const { notifySuccess, notifyError } = useToast()
 
 // State
 const paginationStalled = ref(false)
@@ -732,7 +687,7 @@ const deleteMessage = async () => {
 }
 
 const formatPayload = (payload) => {
-  if (!payload) return 'null'
+  if (payload === null || payload === undefined) return 'null'
   if (typeof payload === 'string') {
     try {
       return JSON.stringify(JSON.parse(payload), null, 2)
@@ -743,81 +698,8 @@ const formatPayload = (payload) => {
   return JSON.stringify(payload, null, 2)
 }
 
-const highlightJson = (payload) => {
-  const json = formatPayload(payload)
-
-  // Tokenize and highlight JSON properly
-  let result = ''
-  let i = 0
-
-  const escapeHtml = (str) => {
-    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  }
-
-  while (i < json.length) {
-    const char = json[i]
-
-    // String
-    if (char === '"') {
-      let str = '"'
-      i++
-      while (i < json.length && json[i] !== '"') {
-        if (json[i] === '\\' && i + 1 < json.length) {
-          str += json[i] + json[i + 1]
-          i += 2
-        } else {
-          str += json[i]
-          i++
-        }
-      }
-      str += '"'
-      i++
-      result += `<span style="color:var(--ok-500)">${escapeHtml(str)}</span>`
-    }
-    // Number
-    else if (char === '-' || (char >= '0' && char <= '9')) {
-      let num = ''
-      while (i < json.length && /[\d.eE+\-]/.test(json[i])) {
-        num += json[i]
-        i++
-      }
-      result += `<span style="color:var(--warn-400)">${num}</span>`
-    }
-    // true, false, null
-    else if (json.slice(i, i + 4) === 'true') {
-      result += '<span style="color:var(--ice-400)">true</span>'
-      i += 4
-    }
-    else if (json.slice(i, i + 5) === 'false') {
-      result += '<span style="color:var(--ice-400)">false</span>'
-      i += 5
-    }
-    else if (json.slice(i, i + 4) === 'null') {
-      result += '<span style="color:var(--ice-400)">null</span>'
-      i += 4
-    }
-    // Braces and brackets
-    else if (char === '{' || char === '}' || char === '[' || char === ']') {
-      result += `<span style="color:var(--text-low)">${char}</span>`
-      i++
-    }
-    // Colon
-    else if (char === ':') {
-      result += '<span style="color:var(--text-faint)">:</span>'
-      i++
-    }
-    // Everything else (whitespace, commas)
-    else {
-      result += escapeHtml(char)
-      i++
-    }
-  }
-
-  return result
-}
-
 const copyPayload = async () => {
-  if (!messageDetail.value?.payload) return
+  if (!messageDetail.value) return
 
   try {
     const text = formatPayload(messageDetail.value.payload)
@@ -826,8 +708,8 @@ const copyPayload = async () => {
     setTimeout(() => {
       payloadCopied.value = false
     }, 2000)
-  } catch (err) {
-    console.error('Failed to copy:', err)
+  } catch {
+    notifyError('Could not copy to the clipboard', 'Copy failed')
   }
 }
 
@@ -867,16 +749,3 @@ watch([filterQueue, filterPartition, filterStatus], () => {
   fetchMessages()
 })
 </script>
-
-<style scoped>
-/* The drawer shell (`.drawer-panel`) and its scrim (`.modal-backdrop`) are
-   shared rules in style.css now — every drawer in the app is the same 640px
-   panel over the same scrim. Only the payload box below is this view's own. */
-
-/* Payload: recessed against the drawer, hairline to close the box. */
-.msg-code {
-  border: 1px solid var(--bd); border-radius: var(--r-card);
-  padding: 14px 16px; overflow-x: auto;
-  background: var(--recessed);
-}
-</style>

--- a/app/src/views/Traces.vue
+++ b/app/src/views/Traces.vue
@@ -292,34 +292,21 @@
       </div>
     </div>
 
-    <!-- Trace detail drawer (teleported to body to avoid transform issues).
-         Backdrop first, so DOM order matches paint order. -->
-    <Teleport to="body">
-      <div
-        v-if="selectedTrace"
-        class="modal-backdrop"
-        @click="selectedTrace = null"
-      ></div>
+    <DetailDrawer
+      :open="Boolean(selectedTrace)"
+      :title="selectedTrace ? `${selectedTrace.event_type} trace` : 'Trace detail'"
+      @close="selectedTrace = null"
+    >
+      <template #leading>
+        <span
+          v-if="selectedTrace"
+          style="width:10px; height:10px; border-radius:var(--r-pill); flex-shrink:0;"
+          :style="{ background: eventColor(selectedTrace.event_type) }"
+        />
+      </template>
 
-      <div v-if="selectedTrace" class="drawer-panel">
-        <div class="card-header">
-          <span
-            style="width:10px; height:10px; border-radius:var(--r-pill); flex-shrink:0;"
-            :style="{ background: eventColor(selectedTrace.event_type) }"
-          />
-          <h3>{{ selectedTrace.event_type }} trace</h3>
-          <button
-            class="btn btn-ghost btn-icon modal-close"
-            @click="selectedTrace = null"
-          >
-            <svg style="width:18px; height:18px;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <div class="card-body">
-          <div style="display:flex; flex-direction:column; gap:20px;">
+      <template v-if="selectedTrace">
+        <div style="display:flex; flex-direction:column; gap:20px;">
             <!-- Basic Info -->
             <div style="display:flex; flex-direction:column; gap:14px;">
               <div>
@@ -381,20 +368,20 @@
                 </div>
               </div>
             </div>
-          </div>
         </div>
+      </template>
 
-        <div class="modal-foot">
-          <router-link
-            :to="`/messages?partitionId=${selectedTrace.partition_id}&transactionId=${selectedTrace.transaction_id}`"
-            class="btn"
-            @click="selectedTrace = null"
-          >
-            View Full Message
-          </router-link>
-        </div>
-      </div>
-    </Teleport>
+      <template #footer>
+        <router-link
+          v-if="selectedTrace"
+          :to="`/messages?partitionId=${selectedTrace.partition_id}&transactionId=${selectedTrace.transaction_id}`"
+          class="btn"
+          @click="selectedTrace = null"
+        >
+          View Full Message
+        </router-link>
+      </template>
+    </DetailDrawer>
   </div>
 </template>
 
@@ -406,6 +393,7 @@ import { formatTimestamp, formatTimestampUtc } from '@/composables/useFormat'
 import { useRefresh } from '@/composables/useRefresh'
 import { stamp } from '@/composables/useStamp'
 import { useIdentity } from '@/stores/identity'
+import DetailDrawer from '@/components/DetailDrawer.vue'
 
 const { actingTenantSlug, actingClusterSlug, actingCellSlug } = useIdentity()
 


### PR DESCRIPTION
## Summary

- align the Messages drawer with the upgraded two-column DLQ detail layout
- extract reusable drawer, copyable field, and JSON viewer components
- use the shared drawer shell for Messages, DLQ, and Traces while keeping view-specific actions and data handling
- preserve responsive fallback to the compact single-column drawer

## Verification

- `npm run build`
- `npm test` (31 tests)
- visually compared Messages and DLQ drawers with representative data
- verified matching 1120px desktop width and column proportions
- verified no header overflow or browser console errors