### PR TITLE
Fix message drawer two-column layout

### DIFF
--- a/app/src/components/DetailDrawer.vue
+++ b/app/src/components/DetailDrawer.vue
@@ -5,7 +5,7 @@
     <aside
       v-if="open"
       class="drawer-panel"
-      :class="{ 'detail-drawer-wide': wide }"
+      :class="{ 'detail-drawer-wide': $slots.secondary }"
       role="dialog"
       aria-modal="true"
       :aria-label="title"
@@ -28,8 +28,10 @@
         </button>
       </div>
 
-      <div class="card-body" :class="{ 'detail-drawer-split': split }">
-        <template v-if="split">
+      <!-- A secondary slot is the layout contract: every drawer that supplies
+           one gets the same wide, two-column shell without caller flags. -->
+      <div class="card-body" :class="{ 'detail-drawer-split': $slots.secondary }">
+        <template v-if="$slots.secondary">
           <div class="detail-drawer-primary"><slot></slot></div>
           <div class="detail-drawer-secondary"><slot name="secondary"></slot></div>
         </template>
@@ -48,8 +50,6 @@ defineProps({
   open: { type: Boolean, required: true },
   title: { type: String, required: true },
   subtitle: { type: String, default: '' },
-  wide: { type: Boolean, default: false },
-  split: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['close'])

--- a/app/src/views/DeadLetter.vue
+++ b/app/src/views/DeadLetter.vue
@@ -305,8 +305,6 @@
       :open="Boolean(selectedMsg)"
       title="DLQ Message Detail"
       :subtitle="selectedMsg?.transactionId || selectedMsg?.id || ''"
-      wide
-      split
       @close="closeDetail"
     >
       <template #actions>

--- a/app/src/views/Messages.vue
+++ b/app/src/views/Messages.vue
@@ -281,8 +281,6 @@
       :open="Boolean(selectedMessage)"
       title="Message Detail"
       :subtitle="messageDetail?.transactionId || selectedMessage?.transactionId || ''"
-      wide
-      :split="Boolean(messageDetail)"
       @close="closePanel"
     >
       <div v-if="detailLoading" style="text-align:center; padding:48px 0;">


### PR DESCRIPTION
## Summary
- derive the wide, split drawer layout directly from the shared secondary slot
- remove per-view `wide` / `split` flags from Messages and DLQ
- keep Messages in the same two-column shell as DLQ throughout detail loading

## Verification
- `npm test` (31 passing)
- `npm run build`
- browser comparison at 1405px: both drawers render at 1120px with the same 40/60 grid and payload in the right column